### PR TITLE
fix unauthorized note updates in task toggle

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -46,7 +46,11 @@ export async function toggleTaskFromPinned(noteId: string, taskLine: number) {
   if (!hit) return
 
   const nextBody = toggleTaskInMarkdown(data.body, hit)
-  await supabase.from('notes').update({ body: nextBody }).eq('id', noteId)
+  await supabase
+    .from('notes')
+    .update({ body: nextBody })
+    .eq('id', noteId)
+    .eq('user_id', user.id)
 
   revalidatePath('/notes')
   revalidatePath(`/notes/${noteId}`)


### PR DESCRIPTION
## Summary
- ensure task toggle only updates current user's notes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a25df967488327837bc5742a696cf1