### PR TITLE
docs: fix sample body spelling

### DIFF
--- a/src/app/api/init-user/route.ts
+++ b/src/app/api/init-user/route.ts
@@ -20,7 +20,7 @@ Write tasks anywhere in your notes using Markdown checkboxes:
 Only **unchecked** tasks appear under the **Tasks** view, grouped by the note they live in.  
 Click a task’s checkbox in **Tasks** to mark it done in the original note.
 
-## Quick Markdown cheatsheet
+## Quick Markdown cheat sheet
 
 # Heading 1
 ## Heading 2, etc.


### PR DESCRIPTION
## Summary
- fix typo in sample note body from 'cheatsheet' to 'cheat sheet'

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a266871a3083278e387299af73ca92