### PR TITLE
Remove init-user fetch and centralize starter note creation

### DIFF
--- a/src/app/(auth)/login/LoginCard.tsx
+++ b/src/app/(auth)/login/LoginCard.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image'
 import { supabaseClient } from '@/lib/supabase-client'
-import SignInForm from '@/components/auth/SignInForm'
+import SignInForm, { ensureStarterNote } from '@/components/auth/SignInForm'
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -35,7 +35,7 @@ export default function LoginCard() {
       if (!mounted) return
       if (data.session) {
         await syncCookieAndWait(data.session)
-        await fetch('/api/init-user', { method: 'POST' })   // <-- add this line
+        await ensureStarterNote(data.session.user.id)
         router.replace('/notes')
       }
     })
@@ -43,7 +43,7 @@ export default function LoginCard() {
     const { data: sub } = supabaseClient.auth.onAuthStateChange(async (event, session) => {
       if (event === 'SIGNED_IN' && session) {
         await syncCookieAndWait(session)
-        await fetch('/api/init-user', { method: 'POST' })   // <-- add this line
+        await ensureStarterNote(session.user.id)
         router.replace('/notes')
       }
     })

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -75,7 +75,7 @@ Markdown is a simple formatting language. Here are a few basics:
 `
 
 // --- Helper: ensure a user's first note exists (idempotent) ---
-async function ensureStarterNote(userId: string) {
+export async function ensureStarterNote(userId: string) {
   // Check if user already has any notes
   const { count, error: countErr } = await supabaseClient
     .from('notes')
@@ -125,7 +125,6 @@ export default function SignInForm() {
         const { data } = await supabaseClient.auth.getSession()
         if (data.session) {
           await syncCookieAndWait(data.session)
-          await fetch('/api/init-user', { method: 'POST' })   // <-- add this line
           // Create starter note on FIRST successful sign-in if needed
           await ensureStarterNote(data.session.user.id)
           router.replace('/notes')


### PR DESCRIPTION
## Summary
- remove `/api/init-user` fetch calls in auth flow
- export and reuse `ensureStarterNote` to handle starter note creation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a26689d8e48327b7d93b2dff8ed846