### PR TITLE
refactor: extract auth sync helper

### DIFF
--- a/src/app/(auth)/login/LoginCard.tsx
+++ b/src/app/(auth)/login/LoginCard.tsx
@@ -6,24 +6,7 @@ import SignInForm, { ensureStarterNote } from '@/components/auth/SignInForm'
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import type { Session } from '@supabase/supabase-js'
-
-async function syncCookieAndWait(session: Session) {
-  await fetch('/auth/refresh', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ event: 'SIGNED_IN' as const, session }),
-  })
-
-  // Poll server until it sees the cookie
-  for (let i = 0; i < 20; i++) {
-    const w = await fetch('/auth/whoami', { cache: 'no-store' })
-    const j: unknown = await w.json().catch(() => ({}))
-    if ((j as { user?: unknown })?.user) return true
-    await new Promise((res) => setTimeout(res, 100))
-  }
-  return false
-}
+import { syncCookieAndWait } from '@/lib/auth-sync'
 
 export default function LoginCard() {
   const router = useRouter()

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -2,29 +2,12 @@
 
 import { useState, FormEvent } from 'react'
 import { useRouter } from 'next/navigation'
-import type { Session } from '@supabase/supabase-js'
 import { supabaseClient } from '@/lib/supabase-client'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
+import { syncCookieAndWait } from '@/lib/auth-sync'
 
-// --- Helper: sync server cookies then wait until the server sees the session ---
-async function syncCookieAndWait(session: Session) {
-  await fetch('/auth/refresh', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ event: 'SIGNED_IN' as const, session }),
-  })
-
-  // Poll server until it reports a user (prevents redirect loops)
-  for (let i = 0; i < 20; i++) {
-    const w = await fetch('/auth/whoami', { cache: 'no-store' })
-    const j = await w.json().catch(() => ({}))
-    if ((j as { user?: unknown })?.user) return true
-    await new Promise((res) => setTimeout(res, 100))
-  }
-  return false
-}
 
 // --- Sample note content (Markdown) ---
 const SAMPLE_NOTE_TITLE = 'Sample Note — Start Here'

--- a/src/lib/auth-sync.ts
+++ b/src/lib/auth-sync.ts
@@ -1,0 +1,17 @@
+import type { Session } from '@supabase/supabase-js'
+
+export async function syncCookieAndWait(session: Session): Promise<boolean> {
+  await fetch('/auth/refresh', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ event: 'SIGNED_IN' as const, session }),
+  })
+
+  for (let i = 0; i < 20; i++) {
+    const w = await fetch('/auth/whoami', { cache: 'no-store' })
+    const j: unknown = await w.json().catch(() => ({}))
+    if ((j as { user?: unknown })?.user) return true
+    await new Promise((res) => setTimeout(res, 100))
+  }
+  return false
+}


### PR DESCRIPTION
## Summary
- refactor auth cookie sync logic into reusable helper
- update login and sign-in components to use helper

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a26a6c21888327af088ce0f0a7d9e3