### PR TITLE
Call init-user endpoint after auth

### DIFF
--- a/src/app/(auth)/login/LoginCard.tsx
+++ b/src/app/(auth)/login/LoginCard.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image'
 import { supabaseClient } from '@/lib/supabase-client'
-import SignInForm, { ensureStarterNote } from '@/components/auth/SignInForm'
+import SignInForm from '@/components/auth/SignInForm'
 import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -35,7 +35,9 @@ export default function LoginCard() {
       if (!mounted) return
       if (data.session) {
         await syncCookieAndWait(data.session)
-        await ensureStarterNote(data.session.user.id)
+        await fetch('/api/init-user', { method: 'POST' }).catch((err) =>
+          console.error('init-user error', err)
+        )
         router.replace('/notes')
       }
     })
@@ -43,7 +45,9 @@ export default function LoginCard() {
     const { data: sub } = supabaseClient.auth.onAuthStateChange(async (event, session) => {
       if (event === 'SIGNED_IN' && session) {
         await syncCookieAndWait(session)
-        await ensureStarterNote(session.user.id)
+        await fetch('/api/init-user', { method: 'POST' }).catch((err) =>
+          console.error('init-user error', err)
+        )
         router.replace('/notes')
       }
     })


### PR DESCRIPTION
## Summary
- call `/api/init-user` from sign-in and login flows
- harden `/api/init-user` with error logging and idempotent behavior

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a26a88ee3483279a8986cb14c3b46e