### PR TITLE
chore: adopt supabase ssr helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,6 @@
         "@radix-ui/react-navigation-menu": "^1.2.13",
         "@radix-ui/react-separator": "^1.1.7",
         "@radix-ui/react-slot": "^1.2.3",
-        "@supabase/auth-ui-react": "^0.4.7",
-        "@supabase/auth-ui-shared": "^0.1.8",
         "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.55.0",
         "@tailwindcss/typography": "^0.5.16",
@@ -2651,12 +2649,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@stitches/core": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@stitches/core/-/core-1.2.8.tgz",
-      "integrity": "sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==",
-      "license": "MIT"
-    },
     "node_modules/@supabase/auth-js": {
       "version": "2.71.1",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.71.1.tgz",
@@ -2664,64 +2656,6 @@
       "license": "MIT",
       "dependencies": {
         "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/auth-ui-react": {
-      "version": "0.4.7",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-ui-react/-/auth-ui-react-0.4.7.tgz",
-      "integrity": "sha512-Lp4FQGFh7BMX1Y/BFaUKidbryL7eskj1fl6Lby7BeHrTctbdvDbCMjVKS8wZ2rxuI8FtPS2iU900fSb70FHknQ==",
-      "dependencies": {
-        "@stitches/core": "^1.2.8",
-        "@supabase/auth-ui-shared": "0.1.8",
-        "prop-types": "^15.7.2",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
-      },
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.21.0"
-      }
-    },
-    "node_modules/@supabase/auth-ui-react/node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@supabase/auth-ui-react/node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
-      },
-      "peerDependencies": {
-        "react": "^18.3.1"
-      }
-    },
-    "node_modules/@supabase/auth-ui-react/node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
-    "node_modules/@supabase/auth-ui-shared": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-ui-shared/-/auth-ui-shared-0.1.8.tgz",
-      "integrity": "sha512-ouQ0DjKcEFg+0gZigFIEgu01V3e6riGZPzgVD0MJsCBNsMsiDT74+GgCEIElMUpTGkwSja3xLwdFRFgMNFKcjg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.21.0"
       }
     },
     "node_modules/@supabase/functions-js": {
@@ -6953,6 +6887,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -7426,6 +7361,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -8567,6 +8503,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8970,6 +8907,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -9043,6 +8981,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-markdown": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,6 @@
     "@radix-ui/react-navigation-menu": "^1.2.13",
     "@radix-ui/react-separator": "^1.1.7",
     "@radix-ui/react-slot": "^1.2.3",
-    "@supabase/auth-ui-react": "^0.4.7",
-    "@supabase/auth-ui-shared": "^0.1.8",
     "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.55.0",
     "@tailwindcss/typography": "^0.5.16",

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -1,5 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
-export const supabaseClient = createClient(
+import { createBrowserClient } from '@supabase/ssr'
+
+export const supabaseClient = createBrowserClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
   process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
 )

--- a/src/lib/supabase-server.ts
+++ b/src/lib/supabase-server.ts
@@ -15,11 +15,14 @@ export async function supabaseServer() {
     {
       cookies: {
         // RSC: allowed to read
-        getAll() {
-          return cookieStore.getAll().map(({ name, value }) => ({ name, value }))
+        get(name: string) {
+          return cookieStore.get(name)?.value
         },
         // RSC: not allowed to write — leave as no-op
-        setAll() {
+        set() {
+          /* no-op on purpose */
+        },
+        remove() {
           /* no-op on purpose */
         },
       },


### PR DESCRIPTION
## Summary
- replace deprecated Supabase auth helpers with `@supabase/ssr`
- update client and server utilities for new helper API
- drop unused `@supabase/auth-ui-react` and `@supabase/auth-ui-shared`

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2807a51388327992d5920c14a5cc2