### PR TITLE
refactor: harden init-user endpoint

### DIFF
--- a/src/app/api/init-user/route.ts
+++ b/src/app/api/init-user/route.ts
@@ -61,8 +61,12 @@ export async function POST() {
 
   try {
     // Must be signed in
-    const { data: { user }, error: userErr } = await supabase.auth.getUser()
+    const {
+      data: { user },
+      error: userErr,
+    } = await supabase.auth.getUser()
     if (userErr || !user) {
+      if (userErr) console.error('get user error', userErr)
       return NextResponse.json({ ok: false, reason: 'no_user' }, { status: 401 })
     }
 
@@ -86,7 +90,7 @@ export async function POST() {
         title: SAMPLE_TITLE,
         body: SAMPLE_BODY,
       })
-      if (insertErr) {
+      if (insertErr && insertErr.code !== '23505') {
         console.error('insert sample note error', insertErr)
         return NextResponse.json(
           { ok: false, reason: 'insert_error', error: insertErr.message },


### PR DESCRIPTION
## Summary
- harden init-user endpoint with extra error handling

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3593919ec8327829b324c7ede9672