### PR TITLE
Handle unbulleted task checkboxes

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -2,6 +2,7 @@
 
 import { supabaseServer } from '@/lib/supabase-server'
 import { extractTasks, toggleTaskInMarkdown } from '@/lib/taskparse'
+import { normalizeTasks } from '@/lib/markdown'
 import { revalidatePath } from 'next/cache'
 
 export async function requireUser() {
@@ -19,7 +20,8 @@ export async function createNote(title: string) {
 
 export async function saveNote(id: string, title: string, body: string) {
   const { supabase, user } = await requireUser()
-  await supabase.from('notes').update({ title, body }).eq('id', id).eq('user_id', user.id)
+  const normalized = normalizeTasks(body)
+  await supabase.from('notes').update({ title, body: normalized }).eq('id', id).eq('user_id', user.id)
   revalidatePath(`/notes/${id}`)
   revalidatePath('/notes')
 }

--- a/src/lib/taskparse.test.ts
+++ b/src/lib/taskparse.test.ts
@@ -16,6 +16,13 @@ describe('extractTasks', () => {
     expect(hits.map(h => h.checked)).toEqual([false, true, false, true])
   })
 
+  it('supports bulletless checkboxes', () => {
+    const md = '[ ] todo\n[x] done\n[X] DONE'
+    const hits = extractTasks(md)
+    expect(hits).toHaveLength(3)
+    expect(hits.map(h => h.checked)).toEqual([false, true, true])
+  })
+
   it('ignores tasks inside code fences', () => {
     const md = [
       '```',

--- a/src/lib/taskparse.ts
+++ b/src/lib/taskparse.ts
@@ -8,7 +8,7 @@ export type TaskHit = {
   mark: string
 }
 
-const TASK_RE = /^\s*(?:[-*+]|\d+\.)\s+\[( |x|X)\]\s+(.*)$/
+const TASK_RE = /^\s*(?:(?:[-*+]|\d+\.)\s+)?\[( |x|X)\]\s+(.*)$/
 
 export function extractTasks(md: string): TaskHit[] {
   const out: TaskHit[] = []


### PR DESCRIPTION
## Summary
- support parsing checkboxes that start with `[ ]` or `[x]` without list markers
- cover bulletless checkboxes in task parsing tests
- normalize note bodies before saving to keep task format consistent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3792aab108327b084b8f5ca9b3643