### PR TITLE
Link tasks to note lines

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -50,8 +50,8 @@ export default async function TasksPage() {
                     {group.tasks.map(t => (
                       <li key={t.line} className="flex items-center gap-2">
                         <form action={toggleTaskFromPinned.bind(null, group.id, t.line)}>
-                          <Button 
-                            type="submit" 
+                          <Button
+                            type="submit"
                             title="Mark done"
                             aria-label="Mark done"
                             className="group inline-flex h-5 w-5 items-center justify-center rounded border border-input bg-transparent
@@ -69,10 +69,12 @@ export default async function TasksPage() {
                               strokeLinejoin="round"
                             >
                               <path d="M4 10l3 3 9-9" />
-                            </svg>                     
+                            </svg>
                           </Button>
                         </form>
-                        <span>{t.text}</span>
+                        <Link href={`/notes/${group.id}#L${t.line + 1}`} className="hover:underline">
+                          {t.text}
+                        </Link>
                       </li>
                     ))}
                   </ul>

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -27,20 +27,26 @@ export default function Markdown({ children }: { children: string }) {
           ul: ({ ...props }) => <ul {...props} className="list-disc pl-6 my-1" />,
           ol: ({ ...props }) => <ol {...props} className="list-decimal pl-6 my-1" />,
 
-          // Remove bullets for task items; align checkbox + text
-          li: ({ children, ...props }) => {
+          // Remove bullets for task items; align checkbox + text and expose line numbers
+          li: ({ children, node, ...props }) => {
             const hasCheckbox = React.Children.toArray(children).some(
               (child) =>
                 React.isValidElement(child) &&
                 child.type === 'input' &&
                 (child.props as { type?: string }).type === 'checkbox'
             )
+              const line = (node as { position?: { start?: { line?: number } } })
+                ?.position?.start?.line
+              const className = `${(props as { className?: string }).className ?? ''} ${
+                hasCheckbox ? 'list-none' : ''
+              } flex items-center gap-2 my-0.5 target:bg-accent/30`;
+
             return (
               <li
                 {...props}
-                className={`${(props as { className?: string }).className ?? ''} ${
-                  hasCheckbox ? 'list-none' : ''
-                } flex items-center gap-2 my-0.5`}
+                id={line ? `L${line}` : undefined}
+                data-line={line}
+                className={className}
               >
                 {children}
               </li>


### PR DESCRIPTION
## Summary
- Link pinned tasks directly to their location in the note using a line-number hash.
- Emit `id` and `data-line` attributes for list items in Markdown and highlight targeted items.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a37df499a48327bf7474894616d8d5