### PR TITLE
feat: toggle tasks in markdown via server action

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -32,7 +32,7 @@ export async function deleteNote(id: string) {
   revalidatePath('/notes')
 }
 
-export async function toggleTaskFromPinned(noteId: string, taskLine: number) {
+async function toggleTask(noteId: string, taskLine: number) {
   const { supabase, user } = await requireUser()
   const { data } = await supabase
     .from('notes')
@@ -53,7 +53,11 @@ export async function toggleTaskFromPinned(noteId: string, taskLine: number) {
     .update({ body: nextBody })
     .eq('id', noteId)
     .eq('user_id', user.id)
+}
 
+export async function toggleTaskFromNote(noteId: string, taskLine: number) {
+  await toggleTask(noteId, taskLine)
   revalidatePath('/notes')
   revalidatePath(`/notes/${noteId}`)
+  revalidatePath('/tasks')
 }

--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -53,7 +53,7 @@ export default async function NotePage({
           <Textarea name="body" defaultValue={note.body} className="min-h-[60vh]" />
           <Card>
             <CardContent className="p-4 prose prose-sm max-w-none">
-              <Markdown>{note.body}</Markdown>
+              <Markdown noteId={noteId}>{note.body}</Markdown>
             </CardContent>
           </Card>
         </div>

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -4,7 +4,7 @@ import { supabaseServer } from '@/lib/supabase-server'
 import { redirect } from 'next/navigation'
 import Link from 'next/link'
 import { extractTasks } from '@/lib/taskparse'
-import { toggleTaskFromPinned } from '@/app/actions'
+import { toggleTaskFromNote } from '@/app/actions'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 
@@ -49,7 +49,7 @@ export default async function TasksPage() {
                   <ul className="mt-2 space-y-2">
                     {group.tasks.map(t => (
                       <li key={t.line} className="flex items-center gap-2">
-                        <form action={toggleTaskFromPinned.bind(null, group.id, t.line)}>
+                        <form action={toggleTaskFromNote.bind(null, group.id, t.line)}>
                           <Button
                             type="submit"
                             title="Mark done"

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { normalizeTasks } from '@/lib/markdown'
+import { toggleTaskFromNote } from '@/app/actions'
 
 type CodeProps =
   React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
@@ -15,9 +16,10 @@ type InputProps = React.DetailedHTMLProps<
   HTMLInputElement
 >
 
-export default function Markdown({ children }: { children: string }) {
+export default function Markdown({ children, noteId }: { children: string; noteId: string }) {
   // Normalize task markers outside fenced code blocks
   const normalized = normalizeTasks(children)
+  const [, startTransition] = React.useTransition()
 
   return (
     <div className="prose prose-neutral dark:prose-invert max-w-none">
@@ -53,15 +55,21 @@ export default function Markdown({ children }: { children: string }) {
             )
           },
 
-          // Read-only checkboxes in preview
+          // Checkboxes that toggle tasks via server action
           input: (props: InputProps) => {
             if (props.type === 'checkbox') {
               const { className, ...rest } = props
               return (
                 <input
                   {...rest}
-                  readOnly
                   className={`h-4 w-4 align-middle rounded border border-muted-foreground/40 ${className ?? ''}`}
+                  onClick={e => {
+                    e.preventDefault()
+                    const lineAttr = e.currentTarget.closest('li')?.getAttribute('data-line')
+                    if (!lineAttr) return
+                    const line = parseInt(lineAttr, 10) - 1
+                    startTransition(() => toggleTaskFromNote(noteId, line))
+                  }}
                 />
               )
             }


### PR DESCRIPTION
## Summary
- add client-side checkbox handler in `Markdown` that calls a server action
- implement `toggleTaskFromNote` server action and use it for both notes and tasks
- pass note id to `Markdown` so toggles revalidate notes and task list

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a38027f85883279bdee4184714d4f5