### PR TITLE
Enable task toggling from Markdown preview with shared server action

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -32,7 +32,7 @@ export async function deleteNote(id: string) {
   revalidatePath('/notes')
 }
 
-export async function toggleTaskFromPinned(noteId: string, taskLine: number) {
+async function toggleTask(noteId: string, taskLine: number) {
   const { supabase, user } = await requireUser()
   const { data } = await supabase
     .from('notes')
@@ -53,7 +53,11 @@ export async function toggleTaskFromPinned(noteId: string, taskLine: number) {
     .update({ body: nextBody })
     .eq('id', noteId)
     .eq('user_id', user.id)
+}
 
+export async function toggleTaskFromNote(noteId: string, taskLine: number) {
+  await toggleTask(noteId, taskLine)
   revalidatePath('/notes')
   revalidatePath(`/notes/${noteId}`)
+  revalidatePath('/tasks')
 }

--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -53,7 +53,7 @@ export default async function NotePage({
           <Textarea name="body" defaultValue={note.body} className="min-h-[60vh]" />
           <Card>
             <CardContent className="p-4 prose prose-sm max-w-none">
-              <Markdown>{note.body}</Markdown>
+              <Markdown noteId={noteId}>{note.body}</Markdown>
             </CardContent>
           </Card>
         </div>

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -4,7 +4,7 @@ import { supabaseServer } from '@/lib/supabase-server'
 import { redirect } from 'next/navigation'
 import Link from 'next/link'
 import { extractTasks } from '@/lib/taskparse'
-import { toggleTaskFromPinned } from '@/app/actions'
+import { toggleTaskFromNote } from '@/app/actions'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 
@@ -49,7 +49,7 @@ export default async function TasksPage() {
                   <ul className="mt-2 space-y-2">
                     {group.tasks.map(t => (
                       <li key={t.line} className="flex items-center gap-2">
-                        <form action={toggleTaskFromPinned.bind(null, group.id, t.line)}>
+                        <form action={toggleTaskFromNote.bind(null, group.id, t.line)}>
                           <Button
                             type="submit"
                             title="Mark done"

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -55,7 +55,7 @@ export default function Markdown({ children, noteId }: { children: string; noteI
             )
           },
 
-          // Checkboxes that toggle tasks via server action
+          // Checkboxes that toggle note tasks via server action
           input: (props: InputProps) => {
             if (props.type === 'checkbox') {
               const { className, disabled: _disabled, ...rest } = props

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -58,8 +58,8 @@ export default function Markdown({ children, noteId }: { children: string; noteI
           // Checkboxes that toggle tasks via server action
           input: (props: InputProps) => {
             if (props.type === 'checkbox') {
-              const { className, disabled, ...rest } = props
-              void disabled
+              const { className, disabled: _disabled, ...rest } = props
+              void _disabled
               return (
                 <input
                   {...rest}


### PR DESCRIPTION
## Summary
- allow Markdown checkboxes to toggle tasks via server action
- share `toggleTaskFromNote` for notes and tasks pages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a38027f85883279bdee4184714d4f5