### PR TITLE
Improve task completion UI with undo and accessibility

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
+import { cn } from '@/lib/utils'
 
 export default async function TasksPage({ searchParams }: { searchParams: Promise<Record<string, string | string[] | undefined>> }) {
   const supabase = await supabaseServer()
@@ -108,19 +109,14 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
                   <ul className="mt-2 space-y-2">
                     {group.tasks.map(t => (
                       <li key={t.line} className="flex items-center gap-2">
-                        <form action={toggleTaskFromNote.bind(null, group.id, t.line)}>
-                          <Button
-                            type="submit"
-                            title="Mark done"
-                            aria-label="Mark done"
-                            className="group inline-flex h-5 w-5 items-center justify-center rounded border border-input bg-transparent
-                                      text-transparent transition-colors
-                                      hover:bg-foreground hover:text-background"
+                        {t.checked ? (
+                          <div
+                            className="inline-flex h-5 w-5 items-center justify-center rounded border border-input bg-transparent text-foreground"
+                            aria-hidden="true"
                           >
-                            {/* ✓ appears only on hover */}
                             <svg
                               viewBox="0 0 20 20"
-                              className="h-3.5 w-3.5 opacity-0 group-hover:opacity-100"
+                              className="h-3.5 w-3.5"
                               fill="none"
                               stroke="currentColor"
                               strokeWidth="3"
@@ -129,24 +125,72 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
                             >
                               <path d="M4 10l3 3 9-9" />
                             </svg>
-                          </Button>
-                        </form>
-                        <Link href={`/notes/${group.id}#L${t.line + 1}`} className="hover:underline">
-                          {t.text}
-                        </Link>
-                        {t.due && (
-                          <span className="text-xs text-muted-foreground">due {t.due}</span>
+                          </div>
+                        ) : (
+                          <form action={toggleTaskFromNote.bind(null, group.id, t.line)}>
+                            <Button
+                              type="submit"
+                              title="Mark done"
+                              aria-label="Mark done"
+                              className="group inline-flex h-5 w-5 items-center justify-center rounded border border-input bg-transparent
+                                      text-transparent transition-colors
+                                      hover:bg-foreground hover:text-background"
+                            >
+                              {/* ✓ appears only on hover */}
+                              <svg
+                                viewBox="0 0 20 20"
+                                className="h-3.5 w-3.5 opacity-0 group-hover:opacity-100"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="3"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              >
+                                <path d="M4 10l3 3 9-9" />
+                              </svg>
+                            </Button>
+                          </form>
                         )}
-                        {t.status && (
-                          <Badge variant="outline" className="text-xs">
-                            {t.status}
-                          </Badge>
+                        <div
+                          className={cn(
+                            "flex flex-wrap items-center gap-2",
+                            t.checked && "text-muted-foreground line-through"
+                          )}
+                          aria-label={t.checked ? "Task completed" : "Task not completed"}
+                        >
+                          <Link
+                            href={`/notes/${group.id}#L${t.line + 1}`}
+                            className="hover:underline"
+                          >
+                            {t.text}
+                          </Link>
+                          {t.due && (
+                            <span className="text-xs text-muted-foreground">due {t.due}</span>
+                          )}
+                          {t.status && (
+                            <Badge variant="outline" className="text-xs">
+                              {t.status}
+                            </Badge>
+                          )}
+                          {t.tags.map(tag => (
+                            <Badge key={tag} variant="secondary" className="text-xs">
+                              #{tag}
+                            </Badge>
+                          ))}
+                        </div>
+                        {t.checked && (
+                          <form action={toggleTaskFromNote.bind(null, group.id, t.line)}>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              type="submit"
+                              title="Reopen task"
+                              aria-label="Reopen task"
+                            >
+                              Undo
+                            </Button>
+                          </form>
                         )}
-                        {t.tags.map(tag => (
-                          <Badge key={tag} variant="secondary" className="text-xs">
-                            #{tag}
-                          </Badge>
-                        ))}
                       </li>
                     ))}
                   </ul>


### PR DESCRIPTION
## Summary
- Visually distinguish completed tasks with muted, struck-through text
- Replace "Mark done" button with check icon and optional undo control
- Include ARIA labels to announce completion state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a3b5dd55e48327bc29091cc3c3c6d0