### PR TITLE
Replace note ID input with note selector and remove note filter

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -31,15 +31,17 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
 
   const params = await searchParams
 
+  const noteId = typeof params.note === 'string' ? params.note : undefined
+
   const filters: TaskFilters = {
     status: typeof params.status === 'string' ? params.status : undefined,
-    note: typeof params.note === 'string' ? params.note : undefined,
     tag: typeof params.tag === 'string' ? params.tag : undefined,
     due: typeof params.due === 'string' ? params.due : undefined,
     sort: typeof params.sort === 'string' ? params.sort : undefined,
   }
 
-  const filtered = filterTasks(tasks, filters)
+  const scoped = noteId ? tasks.filter(t => t.noteId === noteId) : tasks
+  const filtered = filterTasks(scoped, filters)
 
   const groups: { id: string; title: string; tasks: typeof filtered }[] = []
   for (const t of filtered) {
@@ -68,12 +70,18 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
               <option value="open">Open</option>
               <option value="done">Done</option>
             </select>
-            <Input
+            <select
               name="note"
-              placeholder="Note ID"
-              defaultValue={filters.note ?? ''}
-              className="w-24"
-            />
+              defaultValue={noteId ?? ''}
+              className="h-9 rounded-md border border-input bg-transparent px-2"
+            >
+              <option value="">All Notes</option>
+              {notes?.map(n => (
+                <option key={n.id} value={n.id}>
+                  {n.title || 'Untitled'}
+                </option>
+              ))}
+            </select>
             <Input
               name="tag"
               placeholder="Tag"

--- a/src/lib/taskparse.ts
+++ b/src/lib/taskparse.ts
@@ -86,7 +86,6 @@ export type TaskWithNote = TaskHit & { noteId: string }
 
 export type TaskFilters = {
   status?: string
-  note?: string
   tag?: string
   due?: string
   sort?: string
@@ -96,7 +95,6 @@ export function filterTasks<T extends TaskWithNote>(tasks: T[], filters: TaskFil
   let out = [...tasks]
   if (filters.status === 'open') out = out.filter(t => !t.checked)
   else if (filters.status === 'done') out = out.filter(t => t.checked)
-  if (filters.note) out = out.filter(t => t.noteId === filters.note)
   if (filters.tag) {
     const tag = filters.tag
     out = out.filter(t => t.tags.includes(tag))


### PR DESCRIPTION
## Summary
- simplify task filtering by removing note-based filter in `filterTasks`
- scope tasks by selected note ID and render a note picker dropdown

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a49044f6f4832787ade82aad012d41