### PR TITLE
feat(tasks): label due date filter with helper tooltip

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -83,6 +83,8 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
             <Input
               type="date"
               name="due"
+              placeholder="Due date"
+              title="Selecting a date narrows tasks whose metadata includes due:YYYY-MM-DD"
               defaultValue={filters.due ?? ''}
               className="w-36"
             />


### PR DESCRIPTION
## Summary
- add "Due date" placeholder to task filter input
- explain date filtering via tooltip referencing `due:YYYY-MM-DD`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a494d2c4b08327a87ab0477402fe46