### PR TITLE
feat: add task due date picker

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -4,11 +4,12 @@ import { supabaseServer } from '@/lib/supabase-server'
 import { redirect } from 'next/navigation'
 import Link from 'next/link'
 import { extractTasks, filterTasks, TaskFilters, TaskWithNote } from '@/lib/taskparse'
-import { toggleTaskFromNote } from '@/app/actions'
+import { toggleTaskFromNote, setTaskDueFromNote } from '@/app/actions'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Badge } from '@/components/ui/badge'
+import DueDateInput from '@/components/DueDateInput'
 import { cn } from '@/lib/utils'
 
 export default async function TasksPage({ searchParams }: { searchParams: Promise<Record<string, string | string[] | undefined>> }) {
@@ -172,8 +173,14 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
                           >
                             {t.text}
                           </Link>
-                          {t.due && (
-                            <span className="text-xs text-muted-foreground">due {t.due}</span>
+                          {t.checked ? (
+                            t.due && (
+                              <span className="text-xs text-muted-foreground">due {t.due}</span>
+                            )
+                          ) : (
+                            <form action={setTaskDueFromNote.bind(null, group.id, t.line)}>
+                              <DueDateInput defaultValue={t.due} />
+                            </form>
                           )}
                           {t.status && (
                             <Badge variant="outline" className="text-xs">

--- a/src/components/DueDateInput.tsx
+++ b/src/components/DueDateInput.tsx
@@ -1,0 +1,19 @@
+'use client'
+
+import { Input } from '@/components/ui/input'
+
+type Props = {
+  defaultValue?: string
+}
+
+export default function DueDateInput({ defaultValue }: Props) {
+  return (
+    <Input
+      type="date"
+      name="due"
+      defaultValue={defaultValue ?? ''}
+      className="w-36"
+      onChange={e => e.currentTarget.form?.requestSubmit()}
+    />
+  )
+}


### PR DESCRIPTION
## Summary
- allow editing task due dates through a date picker
- persist due date updates back to note markdown

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a496c9bc0083278a9f4c83517a728e