### PR TITLE
Handle empty task list based on filters

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -53,6 +53,9 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
     g.tasks.push(t)
   }
 
+  const emptyMessage =
+    filters.status === 'done' ? 'No closed tasks' : 'No tasks found'
+
   return (
     <div className="space-y-6">
       <Card>
@@ -106,7 +109,7 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
             <Button type="submit">Apply</Button>
           </form>
           {groups.length === 0 ? (
-            <p className="text-muted-foreground">No open tasks 🎉</p>
+            <p className="text-muted-foreground">{emptyMessage}</p>
           ) : (
             <div className="space-y-6">
               {groups.map(group => (


### PR DESCRIPTION
## Summary
- show dynamic empty task list messages based on active status filter

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a496d80c9083278facb8f3361afefa