### PR TITLE
feat: add metadata status filter

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -35,6 +35,7 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
   const noteId = typeof params.note === 'string' ? params.note : undefined
 
   const filters: TaskFilters = {
+    completion: typeof params.completion === 'string' ? params.completion : undefined,
     status: typeof params.status === 'string' ? params.status : undefined,
     tag: typeof params.tag === 'string' ? params.tag : undefined,
     due: typeof params.due === 'string' ? params.due : undefined,
@@ -55,7 +56,7 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
   }
 
   const emptyMessage =
-    filters.status === 'done' ? 'No closed tasks' : 'No tasks found'
+    filters.completion === 'done' ? 'No closed tasks' : 'No tasks found'
 
   return (
     <div className="space-y-6">
@@ -66,8 +67,8 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
         <CardContent>
           <form className="mb-4 flex flex-wrap gap-2">
             <select
-              name="status"
-              defaultValue={filters.status ?? ''}
+              name="completion"
+              defaultValue={filters.completion ?? ''}
               className="h-9 rounded-md border border-input bg-transparent px-2"
             >
               <option value="">All</option>
@@ -90,6 +91,12 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
               name="tag"
               placeholder="Tag"
               defaultValue={filters.tag ?? ''}
+              className="w-24"
+            />
+            <Input
+              name="status"
+              placeholder="Status"
+              defaultValue={filters.status ?? ''}
               className="w-24"
             />
             <Input

--- a/src/lib/taskparse.test.ts
+++ b/src/lib/taskparse.test.ts
@@ -74,14 +74,19 @@ describe('toggleTaskInMarkdown', () => {
 
 describe('filterTasks', () => {
   const tasks: TaskWithNote[] = [
-    { text: 'a', checked: false, line: 0, start: 0, end: 0, mark: ' ', tags: ['work'], noteId: '1', due: '2024-07-01' },
-    { text: 'b', checked: true, line: 1, start: 0, end: 0, mark: 'x', tags: ['home'], noteId: '1', due: '2024-07-02' },
-    { text: 'c', checked: false, line: 2, start: 0, end: 0, mark: ' ', tags: ['work'], noteId: '2', due: '2024-07-02' },
+    { text: 'a', checked: false, line: 0, start: 0, end: 0, mark: ' ', tags: ['work'], noteId: '1', due: '2024-07-01', status: 'todo' },
+    { text: 'b', checked: true, line: 1, start: 0, end: 0, mark: 'x', tags: ['home'], noteId: '1', due: '2024-07-02', status: 'waiting' },
+    { text: 'c', checked: false, line: 2, start: 0, end: 0, mark: ' ', tags: ['work'], noteId: '2', due: '2024-07-02', status: 'todo' },
   ]
 
-  it('filters by status', () => {
-    const res = filterTasks(tasks, { status: 'open' })
+  it('filters by completion', () => {
+    const res = filterTasks(tasks, { completion: 'open' })
     expect(res.map(t => t.text)).toEqual(['a', 'c'])
+  })
+
+  it('filters by metadata status', () => {
+    const res = filterTasks(tasks, { status: 'waiting' })
+    expect(res.map(t => t.text)).toEqual(['b'])
   })
 
   it('filters by tag and due date', () => {

--- a/src/lib/taskparse.ts
+++ b/src/lib/taskparse.ts
@@ -85,6 +85,7 @@ export function toggleTaskInMarkdown(md: string, hit: TaskHit) {
 export type TaskWithNote = TaskHit & { noteId: string }
 
 export type TaskFilters = {
+  completion?: string
   status?: string
   tag?: string
   due?: string
@@ -93,8 +94,9 @@ export type TaskFilters = {
 
 export function filterTasks<T extends TaskWithNote>(tasks: T[], filters: TaskFilters): T[] {
   let out = [...tasks]
-  if (filters.status === 'open') out = out.filter(t => !t.checked)
-  else if (filters.status === 'done') out = out.filter(t => t.checked)
+  if (filters.completion === 'open') out = out.filter(t => !t.checked)
+  else if (filters.completion === 'done') out = out.filter(t => t.checked)
+  if (filters.status) out = out.filter(t => t.status === filters.status)
   if (filters.tag) {
     const tag = filters.tag
     out = out.filter(t => t.tags.includes(tag))


### PR DESCRIPTION
## Summary
- rename completion filter so `status` metadata can be filtered separately
- expose new `status` metadata filter control on tasks page
- cover completion and metadata status filtering in tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a499ca789483278d06c9fee123f511