### PR TITLE
Update due date handling in filterTasks

### DIFF
--- a/src/lib/taskparse.test.ts
+++ b/src/lib/taskparse.test.ts
@@ -75,13 +75,14 @@ describe('toggleTaskInMarkdown', () => {
 describe('filterTasks', () => {
   const tasks: TaskWithNote[] = [
     { text: 'a', checked: false, line: 0, start: 0, end: 0, mark: ' ', tags: ['work'], noteId: '1', due: '2024-07-01', status: 'todo' },
-    { text: 'b', checked: true, line: 1, start: 0, end: 0, mark: 'x', tags: ['home'], noteId: '1', due: '2024-07-02', status: 'waiting' },
+    { text: 'b', checked: true, line: 1, start: 0, end: 0, mark: 'x', tags: ['home'], noteId: '1', due: '2024-07-03', status: 'waiting' },
     { text: 'c', checked: false, line: 2, start: 0, end: 0, mark: ' ', tags: ['work'], noteId: '2', due: '2024-07-02', status: 'todo' },
+    { text: 'd', checked: false, line: 3, start: 0, end: 0, mark: ' ', tags: [], noteId: '3', status: 'todo' },
   ]
 
   it('filters by completion', () => {
     const res = filterTasks(tasks, { completion: 'open' })
-    expect(res.map(t => t.text)).toEqual(['a', 'c'])
+    expect(res.map(t => t.text)).toEqual(['a', 'c', 'd'])
   })
 
   it('filters by metadata status', () => {
@@ -96,6 +97,6 @@ describe('filterTasks', () => {
 
   it('sorts by due date', () => {
     const res = filterTasks(tasks, { sort: 'due' })
-    expect(res.map(t => t.text)).toEqual(['a', 'b', 'c'])
+    expect(res.map(t => t.text)).toEqual(['a', 'c', 'b', 'd'])
   })
 })

--- a/src/lib/taskparse.ts
+++ b/src/lib/taskparse.ts
@@ -104,7 +104,12 @@ export function filterTasks<T extends TaskWithNote>(tasks: T[], filters: TaskFil
   if (filters.due) out = out.filter(t => t.due === filters.due)
 
   if (filters.sort === 'due') {
-    out.sort((a, b) => (a.due ?? '').localeCompare(b.due ?? ''))
+    const toTime = (d?: string) => {
+      if (!d) return Number.POSITIVE_INFINITY
+      const t = new Date(d).getTime()
+      return Number.isNaN(t) ? Number.POSITIVE_INFINITY : t
+    }
+    out.sort((a, b) => toTime(a.due) - toTime(b.due))
   } else if (filters.sort === 'text') {
     out.sort((a, b) => a.text.localeCompare(b.text))
   }


### PR DESCRIPTION
## Summary
- parse due strings as Date and sort by numeric timestamp
- move tasks without due date to end
- expand tests for chronological ordering and undated tasks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4b14e2cc88327bf150ad4a5605cb0