### PR TITLE
Replace note textarea with inline editor

### DIFF
--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -2,12 +2,10 @@ export const dynamic = 'force-dynamic'
 
 import { supabaseServer } from '@/lib/supabase-server'
 import { redirect } from 'next/navigation'
-import { saveNote, deleteNote } from '@/app/actions'
+import { deleteNote } from '@/app/actions'
 import { Button } from '@/components/ui/button'
-import { Textarea } from '@/components/ui/textarea'
 import { Input } from '@/components/ui/input'
-import { Card, CardContent } from '@/components/ui/card'
-import Markdown from '@/components/Markdown'
+import InlineEditor from '@/components/editor/InlineEditor'
 
 
 export default async function NotePage({
@@ -32,13 +30,6 @@ export default async function NotePage({
   // Capture the id into a serializable primitive for server actions
   const noteId = id
 
-  async function onSave(formData: FormData) {
-    'use server'
-    const title = String(formData.get('title') || '')
-    const body  = String(formData.get('body') || '')
-    await saveNote(noteId, title, body)
-  }
-
   async function onDelete() {
     'use server'
     await deleteNote(noteId)
@@ -47,20 +38,10 @@ export default async function NotePage({
 
   return (
     <div className="space-y-4">
-      <form action={onSave} className="space-y-3">
-        <Input name="title" defaultValue={note.title} className="text-lg font-medium" />
-        <div className="grid gap-3 md:grid-cols-2">
-          <Textarea name="body" defaultValue={note.body} className="min-h-[60vh]" />
-          <Card>
-            <CardContent className="p-4 prose prose-sm max-w-none">
-              <Markdown noteId={noteId}>{note.body}</Markdown>
-            </CardContent>
-          </Card>
-        </div>
-        <div className="flex gap-2">
-          <Button type="submit">Save</Button>
-          <Button formAction={onDelete} variant="outline">Delete</Button>
-        </div>
+      <Input name="title" defaultValue={note.title} className="text-lg font-medium" />
+      <InlineEditor noteId={noteId} initialMarkdown={note.body} />
+      <form action={onDelete}>
+        <Button variant="outline">Delete</Button>
       </form>
     </div>
   )


### PR DESCRIPTION
## Summary
- replace textarea/markdown preview with InlineEditor
- remove manual save button while keeping delete action

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4d61f6a948327a99e3672d0837f7b