### PR TITLE
Remove redundant status filter from task view

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -38,7 +38,6 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
 
   const filters: TaskFilters = {
     completion: typeof params.completion === 'string' ? params.completion : undefined,
-    status: typeof params.status === 'string' ? params.status : undefined,
     tag: typeof params.tag === 'string' ? params.tag : undefined,
     due: typeof params.due === 'string' ? params.due : undefined,
     sort: typeof params.sort === 'string' ? params.sort : undefined,
@@ -101,13 +100,6 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
                 </option>
               ))}
             </select>
-            {/* TODO: Remove Status filter from view filter - redundant with completion */}
-            <Input
-              name="status"
-              placeholder="Status"
-              defaultValue={filters.status ?? ''}
-              className="w-24"
-            />
             <Input
               type="date"
               name="due"

--- a/src/lib/taskparse.test.ts
+++ b/src/lib/taskparse.test.ts
@@ -85,11 +85,6 @@ describe('filterTasks', () => {
     expect(res.map(t => t.text)).toEqual(['a', 'c', 'd'])
   })
 
-  it('filters by metadata status', () => {
-    const res = filterTasks(tasks, { status: 'waiting' })
-    expect(res.map(t => t.text)).toEqual(['b'])
-  })
-
   it('filters by tag and due date', () => {
     const res = filterTasks(tasks, { tag: 'work', due: '2024-07-02' })
     expect(res.map(t => t.text)).toEqual(['c'])

--- a/src/lib/taskparse.ts
+++ b/src/lib/taskparse.ts
@@ -86,7 +86,6 @@ export type TaskWithNote = TaskHit & { noteId: string }
 
 export type TaskFilters = {
   completion?: string
-  status?: string
   tag?: string
   due?: string
   sort?: string
@@ -96,7 +95,6 @@ export function filterTasks<T extends TaskWithNote>(tasks: T[], filters: TaskFil
   let out = [...tasks]
   if (filters.completion === 'open') out = out.filter(t => !t.checked)
   else if (filters.completion === 'done') out = out.filter(t => t.checked)
-  if (filters.status) out = out.filter(t => t.status === filters.status)
   if (filters.tag) {
     const tag = filters.tag
     out = out.filter(t => t.tags.includes(tag))


### PR DESCRIPTION
## Summary
- drop unused Status field from task list filters
- simplify task filtering logic
- adjust tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4d677ecec8327afb6a7eaaea1870b