### PR TITLE
feat: autosave note body from inline editor

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -26,6 +26,14 @@ export async function saveNote(id: string, title: string, body: string) {
   revalidatePath('/notes')
 }
 
+export async function saveNoteInline(id: string, body: string) {
+  const { supabase, user } = await requireUser()
+  const normalized = normalizeTasks(body)
+  await supabase.from('notes').update({ body: normalized }).eq('id', id).eq('user_id', user.id)
+  revalidatePath(`/notes/${id}`)
+  revalidatePath('/notes')
+}
+
 export async function deleteNote(id: string) {
   const { supabase, user } = await requireUser()
   await supabase.from('notes').delete().eq('id', id).eq('user_id', user.id)

--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -39,7 +39,7 @@ export default async function NotePage({
   return (
     <div className="space-y-4">
       <Input name="title" defaultValue={note.title} className="text-lg font-medium" />
-      <InlineEditor markdown={note.body} />
+      <InlineEditor noteId={noteId} markdown={note.body} />
       <form action={onDelete}>
         <Button type="submit" variant="outline">Delete</Button>
       </form>


### PR DESCRIPTION
## Summary
- debounce TipTap updates and autosave markdown via `saveNoteInline`
- pass note ID to `InlineEditor` and persist body only

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4e4e076208327b640b5bac81904cf