### PR TITLE
Configure StarterKit history in InlineEditor

### DIFF
--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -17,7 +17,7 @@ export interface InlineEditorProps {
 
 export default function InlineEditor({ noteId, markdown, onChange }: InlineEditorProps) {
   const editor = useEditor({
-    extensions: [StarterKit, TaskList, TaskItem, Placeholder, Markdown],
+    extensions: [StarterKit.configure({ history: {} }), TaskList, TaskItem, Placeholder, Markdown],
     editorProps: {
       attributes: {
         class: 'focus:outline-none',


### PR DESCRIPTION
## Summary
- configure Tiptap StarterKit history default

## Testing
- `npm test`
- `npm run lint`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4e9a592a88327b82ebc3e0f16a23c