### PR TITLE
feat: add slash command and block menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@tiptap/pm": "^2.26.1",
         "@tiptap/react": "^2.26.1",
         "@tiptap/starter-kit": "^2.26.1",
+        "@tiptap/suggestion": "^2.26.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.539.0",
@@ -3558,6 +3559,20 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/suggestion": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-2.26.1.tgz",
+      "integrity": "sha512-iNWJdQN7h01keNoVwyCsdI7ZX11YkrexZjCnutWK17Dd72s3NYVTmQXu7saftwddT4nDdlczNxAFosrt0zMhcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@tiptap/pm": "^2.26.1",
     "@tiptap/react": "^2.26.1",
     "@tiptap/starter-kit": "^2.26.1",
+    "@tiptap/suggestion": "^2.26.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.539.0",

--- a/src/components/editor/BlockMenu.tsx
+++ b/src/components/editor/BlockMenu.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import * as React from 'react'
+import { BubbleMenu, type Editor } from '@tiptap/react'
+import {
+  Heading2,
+  List,
+  ListOrdered,
+  CheckSquare,
+  Quote,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+export interface BlockMenuProps {
+  editor: Editor | null
+}
+
+export function BlockMenu({ editor }: BlockMenuProps) {
+  if (!editor) return null
+
+  return (
+    <BubbleMenu
+      editor={editor}
+      tippyOptions={{ placement: 'left-start', offset: [-40, 0], duration: 150 }}
+      shouldShow={({ editor }) => editor.isFocused }
+    >
+      <div className="flex flex-col items-center gap-1 rounded-md border bg-background p-1 shadow-md">
+        <Button
+          size="icon"
+          variant={editor.isActive('heading', { level: 2 }) ? 'default' : 'ghost'}
+          onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+        >
+          <Heading2 className="size-4" />
+        </Button>
+        <Button
+          size="icon"
+          variant={editor.isActive('bulletList') ? 'default' : 'ghost'}
+          onClick={() => editor.chain().focus().toggleBulletList().run()}
+        >
+          <List className="size-4" />
+        </Button>
+        <Button
+          size="icon"
+          variant={editor.isActive('orderedList') ? 'default' : 'ghost'}
+          onClick={() => editor.chain().focus().toggleOrderedList().run()}
+        >
+          <ListOrdered className="size-4" />
+        </Button>
+        <Button
+          size="icon"
+          variant={editor.isActive('taskList') ? 'default' : 'ghost'}
+          onClick={() => editor.chain().focus().toggleTaskList().run()}
+        >
+          <CheckSquare className="size-4" />
+        </Button>
+        <Button
+          size="icon"
+          variant={editor.isActive('blockquote') ? 'default' : 'ghost'}
+          onClick={() => editor.chain().focus().toggleBlockquote().run()}
+        >
+          <Quote className="size-4" />
+        </Button>
+      </div>
+    </BubbleMenu>
+  )
+}
+
+export default BlockMenu
+

--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -9,6 +9,8 @@ import TaskItem from '@tiptap/extension-task-item'
 import Placeholder from '@tiptap/extension-placeholder'
 import { Markdown } from 'tiptap-markdown'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
+import { SlashCommand } from './SlashCommand'
+import { BlockMenu } from './BlockMenu'
 
 export interface InlineEditorProps {
   noteId: string
@@ -50,6 +52,7 @@ export default function InlineEditor({ noteId, markdown, onChange }: InlineEdito
       TaskItemExt,
       Placeholder,
       Markdown,
+      SlashCommand,
     ],
     editorProps: {
       attributes: {
@@ -93,6 +96,7 @@ export default function InlineEditor({ noteId, markdown, onChange }: InlineEdito
 
   return (
     <div className="prose prose-neutral dark:prose-invert max-w-none">
+      {editor && <BlockMenu editor={editor} />}
       <EditorContent editor={editor} />
     </div>
   )

--- a/src/components/editor/SlashCommand.tsx
+++ b/src/components/editor/SlashCommand.tsx
@@ -1,0 +1,186 @@
+'use client'
+
+import React from 'react'
+import { Extension, type Range, type Editor } from '@tiptap/core'
+import { ReactRenderer } from '@tiptap/react'
+import Suggestion, { type SuggestionProps } from '@tiptap/suggestion'
+import tippy, { type Instance as TippyInstance } from 'tippy.js'
+import {
+  Heading2,
+  List,
+  ListOrdered,
+  CheckSquare,
+  Quote,
+} from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+interface CommandItem {
+  title: string
+  icon: React.ComponentType<{ className?: string }>
+  command: (props: { editor: Editor; range: Range }) => void
+}
+
+const commandItems: CommandItem[] = [
+  {
+    title: 'Heading',
+    icon: Heading2,
+    command: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).toggleHeading({ level: 2 }).run(),
+  },
+  {
+    title: 'Bulleted List',
+    icon: List,
+    command: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).toggleBulletList().run(),
+  },
+  {
+    title: 'Numbered List',
+    icon: ListOrdered,
+    command: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).toggleOrderedList().run(),
+  },
+  {
+    title: 'Checklist',
+    icon: CheckSquare,
+    command: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).toggleTaskList().run(),
+  },
+  {
+    title: 'Quote',
+    icon: Quote,
+    command: ({ editor, range }) =>
+      editor.chain().focus().deleteRange(range).toggleBlockquote().run(),
+  },
+]
+
+export const SlashCommand = Extension.create({
+  name: 'slash-command',
+
+  addOptions() {
+    return {
+      suggestion: {
+        char: '/',
+        startOfLine: true,
+        items: () => commandItems,
+        render: () => {
+          let component: ReactRenderer<CommandListProps, CommandListRef> | null = null
+          let popup: TippyInstance | null = null
+          return {
+            onStart: (props: SuggestionProps) => {
+              component = new ReactRenderer<CommandListProps, CommandListRef>(
+                CommandList,
+                {
+                  props,
+                  editor: props.editor,
+                }
+              )
+
+              popup = tippy('body', {
+                getReferenceClientRect: props.clientRect,
+                appendTo: () => document.body,
+                content: component.element,
+                showOnCreate: true,
+                interactive: true,
+                placement: 'bottom-start',
+              })
+            },
+            onUpdate(props: SuggestionProps) {
+              component?.updateProps(props)
+              popup?.setProps({
+                getReferenceClientRect: props.clientRect,
+              })
+            },
+            onKeyDown(props: SuggestionProps & { event: KeyboardEvent }) {
+              if (props.event.key === 'Escape') {
+                popup?.hide()
+                return true
+              }
+              return component?.ref?.onKeyDown(props) ?? false
+            },
+            onExit() {
+              popup?.destroy()
+              component?.destroy()
+            },
+          }
+        },
+      },
+    }
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      Suggestion({
+        editor: this.editor,
+        ...this.options.suggestion,
+      }),
+    ]
+  },
+})
+
+interface CommandListProps {
+  items: CommandItem[]
+  command: (item: CommandItem) => void
+}
+
+interface CommandListRef {
+  onKeyDown: (props: { event: KeyboardEvent }) => boolean
+}
+
+const CommandList = React.forwardRef<CommandListRef, CommandListProps>(
+  ({ items, command }, ref) => {
+  const [selectedIndex, setSelectedIndex] = React.useState(0)
+
+  const selectItem = (index: number) => {
+    const item = items[index]
+    if (item) {
+      command(item)
+    }
+  }
+
+  const upHandler = () => {
+    setSelectedIndex((index) => (index + items.length - 1) % items.length)
+  }
+
+  const downHandler = () => {
+    setSelectedIndex((index) => (index + 1) % items.length)
+  }
+
+  React.useImperativeHandle(ref, () => ({
+    onKeyDown: ({ event }) => {
+      if (event.key === 'ArrowUp') {
+        upHandler()
+        return true
+      }
+      if (event.key === 'ArrowDown') {
+        downHandler()
+        return true
+      }
+      if (event.key === 'Enter') {
+        selectItem(selectedIndex)
+        return true
+      }
+      return false
+    },
+  }))
+
+  return (
+    <div className="flex flex-col rounded-md border bg-background p-1 shadow-md">
+      {items.map((item, index) => (
+        <Button
+          key={item.title}
+          variant={index === selectedIndex ? 'default' : 'ghost'}
+          className="justify-start gap-2"
+          onClick={() => selectItem(index)}
+        >
+          <item.icon className="size-4" />
+          {item.title}
+        </Button>
+      ))}
+    </div>
+  )
+}
+)
+CommandList.displayName = 'CommandList'
+
+export default SlashCommand
+


### PR DESCRIPTION
## Summary
- add TipTap slash command to convert blocks to heading, lists, checklist, or quote
- provide hoverable block menu with quick block type conversions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4f066c58c832785b02446a2c492f8