### PR TITLE
test: simulate heavy typing and profile autosave

### DIFF
--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -16,6 +16,8 @@ export interface InlineEditorProps {
   onChange?: (markdown: string) => void
 }
 
+export const AUTOSAVE_THROTTLE_MS = 3000
+
 export default function InlineEditor({ noteId, markdown, onChange }: InlineEditorProps) {
   const TaskItemExt = TaskItem.extend({
     addProseMirrorPlugins() {
@@ -74,7 +76,7 @@ export default function InlineEditor({ noteId, markdown, onChange }: InlineEdito
       if (saveTimeout.current) clearTimeout(saveTimeout.current)
       saveTimeout.current = setTimeout(() => {
         saveNoteInline(noteId, md)
-      }, 2000)
+      }, AUTOSAVE_THROTTLE_MS)
     }
     const blurHandler = () => {
       const md = editor.storage.markdown.getMarkdown()

--- a/src/components/editor/__tests__/typingProfile.test.ts
+++ b/src/components/editor/__tests__/typingProfile.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import TaskList from '@tiptap/extension-task-list'
+import TaskItem from '@tiptap/extension-task-item'
+import Placeholder from '@tiptap/extension-placeholder'
+import { Markdown } from 'tiptap-markdown'
+const AUTOSAVE_THROTTLE_MS = 3000
+
+describe('typing performance and autosave', () => {
+  it('handles 10k-word typing with minimal autosaves', () => {
+    vi.useFakeTimers()
+    const saveNoteInline = vi.fn()
+    let saveTimeout: ReturnType<typeof setTimeout> | null = null
+
+    const editor = new Editor({
+      extensions: [
+        StarterKit.configure({ history: {} }),
+        TaskList,
+        TaskItem,
+        Placeholder,
+        Markdown,
+      ],
+      onUpdate: () => {
+        if (saveTimeout) clearTimeout(saveTimeout)
+        saveTimeout = setTimeout(() => {
+          saveNoteInline()
+        }, AUTOSAVE_THROTTLE_MS)
+      },
+    })
+
+    const words = Array.from({ length: 10000 }, () => 'word')
+    const durations: number[] = []
+
+    for (let i = 0; i < words.length; i++) {
+      const start = performance.now()
+      editor.commands.insertContent(`${words[i]} `)
+      durations.push(performance.now() - start)
+      if ((i + 1) % 1000 === 0) {
+        vi.advanceTimersByTime(AUTOSAVE_THROTTLE_MS + 1)
+      }
+    }
+
+    vi.runAllTimers()
+
+    const avg = durations.reduce((a, b) => a + b, 0) / durations.length
+    expect(avg).toBeLessThan(50)
+    expect(saveNoteInline).toHaveBeenCalledTimes(10)
+
+    vi.useRealTimers()
+  }, 20000)
+})


### PR DESCRIPTION
## Summary
- add vitest that simulates typing a 10k-word document and records autosave behavior
- raise inline editor autosave throttle to 3s to reduce UI lag

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4f4bad17c83279bb50f23d83e3072