### PR TITLE
feat: add slash command extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@tiptap/pm": "^2.26.1",
         "@tiptap/react": "^2.26.1",
         "@tiptap/starter-kit": "^2.26.1",
+        "@tiptap/suggestion": "^2.26.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.539.0",
@@ -3558,6 +3559,20 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/suggestion": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-2.26.1.tgz",
+      "integrity": "sha512-iNWJdQN7h01keNoVwyCsdI7ZX11YkrexZjCnutWK17Dd72s3NYVTmQXu7saftwddT4nDdlczNxAFosrt0zMhcg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@tiptap/pm": "^2.26.1",
     "@tiptap/react": "^2.26.1",
     "@tiptap/starter-kit": "^2.26.1",
+    "@tiptap/suggestion": "^2.26.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.539.0",

--- a/src/components/editor/SlashCommand.tsx
+++ b/src/components/editor/SlashCommand.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import * as React from 'react'
+import type { Editor, Range } from '@tiptap/core'
+import { Extension } from '@tiptap/core'
+import { ReactRenderer } from '@tiptap/react'
+import Suggestion from '@tiptap/suggestion'
+import tippy, { type Instance as TippyInstance } from 'tippy.js'
+
+interface Command {
+  title: string
+  command: (opts: { editor: Editor; range: Range }) => void
+}
+
+export interface CommandListProps {
+  items: Command[]
+  command: (item: Command) => void
+}
+
+export interface CommandListRef {
+  onKeyDown: (props: { event: KeyboardEvent }) => boolean
+}
+
+const CommandList = React.forwardRef<CommandListRef, CommandListProps>(
+  ({ items, command }, ref) => {
+    const [selectedIndex, setSelectedIndex] = React.useState(0)
+
+    const selectItem = (index: number) => {
+      const item = items[index]
+      if (item) {
+        command(item)
+      }
+    }
+
+    const onKeyDown = ({ event }: { event: KeyboardEvent }) => {
+      if (event.key === 'ArrowUp') {
+        setSelectedIndex((index) => (index + items.length - 1) % items.length)
+        return true
+      }
+      if (event.key === 'ArrowDown') {
+        setSelectedIndex((index) => (index + 1) % items.length)
+        return true
+      }
+      if (event.key === 'Enter') {
+        selectItem(selectedIndex)
+        return true
+      }
+      return false
+    }
+
+    React.useImperativeHandle(ref, () => ({
+      onKeyDown,
+    }))
+
+    return (
+      <div className="flex flex-col gap-1 rounded-md border bg-background p-1 shadow-md">
+        {items.map((item, index) => (
+          <button
+            key={index}
+            className={`rounded-sm px-2 py-1 text-left text-sm ${
+              index === selectedIndex ? 'bg-accent text-accent-foreground' : ''
+            }`}
+            onClick={() => selectItem(index)}
+          >
+            {item.title}
+          </button>
+        ))}
+      </div>
+    )
+  }
+)
+CommandList.displayName = 'CommandList'
+
+export const SlashCommand = Extension.create({
+  name: 'slash-command',
+
+  addOptions() {
+    return {
+      suggestion: {
+        char: '/',
+        startOfLine: true,
+        items: ({ query }: { query: string }) => {
+          return [
+            {
+              title: 'Paragraph',
+              command: ({ editor, range }: { editor: Editor; range: Range }) =>
+                editor.chain().focus().deleteRange(range).setParagraph().run(),
+            },
+            {
+              title: 'Heading',
+              command: ({ editor, range }: { editor: Editor; range: Range }) =>
+                editor
+                  .chain()
+                  .focus()
+                  .deleteRange(range)
+                  .toggleHeading({ level: 2 })
+                  .run(),
+            },
+            {
+              title: 'Bullet List',
+              command: ({ editor, range }: { editor: Editor; range: Range }) =>
+                editor
+                  .chain()
+                  .focus()
+                  .deleteRange(range)
+                  .toggleBulletList()
+                  .run(),
+            },
+          ].filter((item) =>
+            item.title.toLowerCase().startsWith(query.toLowerCase())
+          )
+        },
+        render: () => {
+          let component: ReactRenderer<CommandListRef, CommandListProps>
+          let popup: TippyInstance[]
+
+          return {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            onStart: (props: any) => {
+              component = new ReactRenderer<CommandListRef, CommandListProps>(
+                CommandList,
+                {
+                  props: {
+                    items: props.items,
+                    command: (item: Command) => props.command(item),
+                  },
+                  editor: props.editor,
+                }
+              )
+
+              popup = tippy('body', {
+                getReferenceClientRect: props.clientRect as () => DOMRect,
+                appendTo: () => document.body,
+                content: component.element,
+                showOnCreate: true,
+                interactive: true,
+                placement: 'bottom-start',
+              })
+            },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            onUpdate(props: any) {
+              component.updateProps({
+                items: props.items,
+                command: (item: Command) => props.command(item),
+              })
+
+              popup[0].setProps({
+                getReferenceClientRect: props.clientRect as () => DOMRect,
+              })
+            },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            onKeyDown(props: any) {
+              if (props.event.key === 'Escape') {
+                popup[0].hide()
+                return true
+              }
+              return component.ref?.onKeyDown(props) ?? false
+            },
+            onExit() {
+              popup[0].destroy()
+              component.destroy()
+            },
+          }
+        },
+      },
+    }
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      Suggestion({
+        editor: this.editor,
+        ...this.options.suggestion,
+      }),
+    ]
+  },
+})
+
+export default SlashCommand
+


### PR DESCRIPTION
## Summary
- add SlashCommand extension for editor with ReactRenderer generics in correct order
- install @tiptap/suggestion dependency

## Testing
- `npm run lint`
- `npm test` *(fails: src/components/editor/__tests__/typingProfile.test.ts hangs)*
- `npm run build` *(fails: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables required)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f9b5a9788327829ecc11a7da74f4