### PR TITLE
feat: add drag handle for block reordering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@supabase/supabase-js": "^2.55.0",
         "@tailwindcss/typography": "^0.5.16",
         "@tiptap/core": "^2.26.1",
+        "@tiptap/extension-drag-handle": "^2.26.1",
         "@tiptap/extension-placeholder": "^2.26.1",
         "@tiptap/extension-task-item": "^2.26.1",
         "@tiptap/extension-task-list": "^2.26.1",
@@ -3231,6 +3232,22 @@
         "@tiptap/pm": "^2.7.0"
       }
     },
+    "node_modules/@tiptap/extension-collaboration": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration/-/extension-collaboration-2.26.1.tgz",
+      "integrity": "sha512-ozCrGW5IAzi/18Ngdi0v/Q175D7J3ZGoTffDDyPxnTK/oksfROajoe+ZIEgoDGXPeI/I7TTlTONuqQ6LZT5r7Q==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0",
+        "y-prosemirror": "^1.2.11"
+      }
+    },
     "node_modules/@tiptap/extension-document": {
       "version": "2.26.1",
       "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-2.26.1.tgz",
@@ -3242,6 +3259,26 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-drag-handle": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle/-/extension-drag-handle-2.26.1.tgz",
+      "integrity": "sha512-t86p2U2wtvsvA1v9GO9GmJQk68uxXm86uZE3heW10QBcflIPgbUKYOUu/gDF3QNliYlSVBxBRrLX8T7kQXrc8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "tippy.js": "^6.3.7"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/extension-collaboration": "^2.7.0",
+        "@tiptap/extension-node-range": "^2.14.0",
+        "@tiptap/pm": "^2.7.0",
+        "y-prosemirror": "^1.2.5"
       }
     },
     "node_modules/@tiptap/extension-dropcursor": {
@@ -3367,6 +3404,21 @@
       },
       "peerDependencies": {
         "@tiptap/core": "^2.7.0"
+      }
+    },
+    "node_modules/@tiptap/extension-node-range": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-node-range/-/extension-node-range-2.26.1.tgz",
+      "integrity": "sha512-8sVFrifJg267T3EyMNH9P4RTxnI0nUeB+0jFuh8eVo/Se0irphwONIwv6lFhyUhSUUx/S3Ho18ADmXE/SBYNRA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
       }
     },
     "node_modules/@tiptap/extension-ordered-list": {
@@ -7357,6 +7409,17 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/isomorphic.js": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
+      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -7583,6 +7646,28 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lib0": {
+      "version": "0.2.114",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.114.tgz",
+      "integrity": "sha512-gcxmNFzA4hv8UYi8j43uPlQ7CGcyMJ2KQb5kZASw6SnAKAf10hK12i2fjrS3Cl/ugZa5Ui6WwIu1/6MIXiHttQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "isomorphic.js": "^0.2.4"
+      },
+      "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/lightningcss": {
@@ -11862,6 +11947,52 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y-prosemirror": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.3.7.tgz",
+      "integrity": "sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.109"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.7.1",
+        "prosemirror-state": "^1.2.3",
+        "prosemirror-view": "^1.9.10",
+        "y-protocols": "^1.0.1",
+        "yjs": "^13.5.38"
+      }
+    },
+    "node_modules/y-protocols": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
+      "integrity": "sha512-vHRF2L6iT3rwj1jub/K5tYcTT/mEYDUppgNPXwp8fmLpui9f7Yeq3OEtTLVF012j39QnV+KEQpNqoN7CWU7Y9Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
     "node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -11870,6 +12001,24 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/yjs": {
+      "version": "13.6.27",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.27.tgz",
+      "integrity": "sha512-OIDwaflOaq4wC6YlPBy2L6ceKeKuF7DeTxx+jPzv1FHn9tCZ0ZwSRnUBxD05E3yed46fv/FWJbvR+Ud7x0L7zw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lib0": "^0.2.99"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@supabase/supabase-js": "^2.55.0",
     "@tailwindcss/typography": "^0.5.16",
     "@tiptap/core": "^2.26.1",
+    "@tiptap/extension-drag-handle": "^2.26.1",
     "@tiptap/extension-placeholder": "^2.26.1",
     "@tiptap/extension-task-item": "^2.26.1",
     "@tiptap/extension-task-list": "^2.26.1",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -122,3 +122,17 @@
     @apply bg-background text-foreground;
   }
 }
+
+.drag-handle {
+  @apply flex h-4 w-4 cursor-grab items-center justify-center rounded-sm bg-muted text-muted-foreground;
+}
+
+.drag-handle:active {
+  @apply cursor-grabbing;
+}
+
+.drag-handle::before {
+  content: '⋮⋮';
+  font-size: 0.5rem;
+  line-height: 1;
+}

--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -9,6 +9,7 @@ import TaskItem from '@tiptap/extension-task-item'
 import Placeholder from '@tiptap/extension-placeholder'
 import { Markdown } from 'tiptap-markdown'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
+import DragHandle from '@tiptap/extension-drag-handle'
 
 export interface InlineEditorProps {
   noteId: string
@@ -18,7 +19,7 @@ export interface InlineEditorProps {
 
 export const AUTOSAVE_THROTTLE_MS = 3000
 
-export default function InlineEditor({ noteId, markdown, onChange }: InlineEditorProps) {
+export function createInlineEditorExtensions() {
   const TaskItemExt = TaskItem.extend({
     addProseMirrorPlugins() {
       const name = this.name
@@ -45,14 +46,19 @@ export default function InlineEditor({ noteId, markdown, onChange }: InlineEdito
     },
   })
 
+  return [
+    StarterKit.configure({ history: {} }),
+    TaskList,
+    TaskItemExt,
+    Placeholder,
+    Markdown,
+    DragHandle,
+  ]
+}
+
+export default function InlineEditor({ noteId, markdown, onChange }: InlineEditorProps) {
   const editor = useEditor({
-    extensions: [
-      StarterKit.configure({ history: {} }),
-      TaskList,
-      TaskItemExt,
-      Placeholder,
-      Markdown,
-    ],
+    extensions: createInlineEditorExtensions(),
     editorProps: {
       attributes: {
         class: 'focus:outline-none',

--- a/src/components/editor/__tests__/dragHandle.test.ts
+++ b/src/components/editor/__tests__/dragHandle.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest'
+
+import { createInlineEditorExtensions } from '../InlineEditor'
+
+describe('Drag handle extension', () => {
+  it('is included in inline editor extensions', () => {
+    const extensions = createInlineEditorExtensions()
+    const names = extensions.map(ext => ext.name)
+    expect(names).toContain('dragHandle')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,12 @@
 import { defineConfig } from 'vitest/config'
+import path from 'path'
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary
- integrate Tiptap drag handle for block reordering
- style drag handle and expose editor extensions factory
- configure Vitest alias and add unit test for drag handle

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a550c7807483278eac77892acbb800