### PR TITLE
feat(editor): improve list item keyboard rules

### DIFF
--- a/src/components/editor/__tests__/listItemRules.test.ts
+++ b/src/components/editor/__tests__/listItemRules.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { Editor } from '@tiptap/core'
+import { createInlineEditorExtensions } from '../InlineEditor'
+
+describe('list item input rules', () => {
+  it('Enter creates a new list item', () => {
+    const extensions = createInlineEditorExtensions().filter(e => e.name !== 'dragHandle')
+    const editor = new Editor({ extensions })
+
+    editor.commands.toggleBulletList()
+    editor.commands.insertContent('one')
+    editor.commands.enter()
+
+    const json = editor.getJSON()
+    expect(json.content?.[0].type).toBe('bulletList')
+    expect(json.content?.[0].content).toHaveLength(2)
+  })
+
+  it('Enter on empty item exits the list', () => {
+    const extensions = createInlineEditorExtensions().filter(e => e.name !== 'dragHandle')
+    const editor = new Editor({ extensions })
+
+    editor.commands.toggleBulletList()
+    editor.commands.insertContent('one')
+    editor.commands.enter()
+    editor.commands.enter()
+
+    const json = editor.getJSON()
+    expect(json.content?.[0].type).toBe('bulletList')
+    expect(json.content?.[0].content).toHaveLength(1)
+    expect(json.content?.[1].type).toBe('paragraph')
+  })
+
+  it('Backspace at start converts item to paragraph', () => {
+    const extensions = createInlineEditorExtensions().filter(e => e.name !== 'dragHandle')
+    const editor = new Editor({ extensions })
+
+    editor.commands.toggleBulletList()
+    editor.commands.insertContent('one')
+    const { from } = editor.state.selection
+    editor.commands.setTextSelection({ from: from - 3, to: from - 3 })
+    editor.commands.keyboardShortcut('Backspace')
+
+    const json = editor.getJSON()
+    expect(json.content?.[0].type).toBe('paragraph')
+    expect(json.content?.[0].content?.[0].text).toBe('one')
+  })
+})


### PR DESCRIPTION
## Summary
- customize list item keyboard shortcuts to split items on Enter, exit on empty, and lift on Backspace
- add tests verifying list behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a55443f33083278eacab4b3897b7b8