### PR TITLE
feat(editor): improve keyboard navigation and accessibility

### DIFF
--- a/src/components/editor/FloatingToolbar.tsx
+++ b/src/components/editor/FloatingToolbar.tsx
@@ -26,6 +26,7 @@ export function FloatingToolbar({ editor }: FloatingToolbarProps) {
       editor={editor}
       tippyOptions={{
         duration: 150,
+        interactive: true,
       }}
       shouldShow={({ editor }) =>
         !editor.state.selection.empty && editor.isFocused
@@ -33,20 +34,35 @@ export function FloatingToolbar({ editor }: FloatingToolbarProps) {
     >
       <div className="flex items-center gap-1 rounded-md border bg-background p-1 shadow-md">
         <Button
+          type="button"
           size="icon"
           variant={editor.isActive('bold') ? 'default' : 'ghost'}
           onClick={() => editor.chain().focus().toggleBold().run()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              editor.chain().focus().toggleBold().run()
+            }
+          }}
         >
           <Bold className="size-4" />
         </Button>
         <Button
+          type="button"
           size="icon"
           variant={editor.isActive('italic') ? 'default' : 'ghost'}
           onClick={() => editor.chain().focus().toggleItalic().run()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              editor.chain().focus().toggleItalic().run()
+            }
+          }}
         >
           <Italic className="size-4" />
         </Button>
         <Button
+          type="button"
           size="icon"
           variant={
             editor.isActive('heading', { level: 2 }) ? 'default' : 'ghost'
@@ -54,34 +70,68 @@ export function FloatingToolbar({ editor }: FloatingToolbarProps) {
           onClick={() =>
             editor.chain().focus().toggleHeading({ level: 2 }).run()
           }
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              editor.chain().focus().toggleHeading({ level: 2 }).run()
+            }
+          }}
         >
           <Heading2 className="size-4" />
         </Button>
         <Button
+          type="button"
           size="icon"
           variant={editor.isActive('bulletList') ? 'default' : 'ghost'}
           onClick={() => editor.chain().focus().toggleBulletList().run()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              editor.chain().focus().toggleBulletList().run()
+            }
+          }}
         >
           <List className="size-4" />
         </Button>
         <Button
+          type="button"
           size="icon"
           variant={editor.isActive('orderedList') ? 'default' : 'ghost'}
           onClick={() => editor.chain().focus().toggleOrderedList().run()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              editor.chain().focus().toggleOrderedList().run()
+            }
+          }}
         >
           <ListOrdered className="size-4" />
         </Button>
         <Button
+          type="button"
           size="icon"
           variant={editor.isActive('taskList') ? 'default' : 'ghost'}
           onClick={() => editor.chain().focus().toggleTaskList().run()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              editor.chain().focus().toggleTaskList().run()
+            }
+          }}
         >
           <CheckSquare className="size-4" />
         </Button>
         <Button
+          type="button"
           size="icon"
           variant={editor.isActive('blockquote') ? 'default' : 'ghost'}
           onClick={() => editor.chain().focus().toggleBlockquote().run()}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              editor.chain().focus().toggleBlockquote().run()
+            }
+          }}
         >
           <Quote className="size-4" />
         </Button>

--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -12,6 +12,7 @@ import { Markdown } from 'tiptap-markdown'
 import { Plugin, PluginKey } from '@tiptap/pm/state'
 import DragHandle from '@tiptap/extension-drag-handle'
 import DOMPurify from 'dompurify'
+import { Extension } from '@tiptap/core'
 
 export interface InlineEditorProps {
   noteId: string
@@ -107,6 +108,35 @@ export function createInlineEditorExtensions() {
     },
   })
 
+  const ArrowNavigation = Extension.create({
+    addKeyboardShortcuts() {
+      return {
+        ArrowUp: () => {
+          const { state, commands } = this.editor
+          const { $from } = state.selection
+          if ($from.parentOffset === 0) {
+            const prevPos = Math.max(0, $from.before() - 1)
+            const resolved = state.doc.resolve(prevPos)
+            commands.focus(resolved.pos)
+            return true
+          }
+          return false
+        },
+        ArrowDown: () => {
+          const { state, commands } = this.editor
+          const { $from } = state.selection
+          if ($from.parentOffset === $from.parent.content.size) {
+            const nextPos = Math.min(state.doc.content.size, $from.after())
+            const resolved = state.doc.resolve(nextPos)
+            commands.focus(resolved.pos)
+            return true
+          }
+          return false
+        },
+      }
+    },
+  })
+
   return [
     StarterKit.configure({ history: {}, listItem: false }),
     ListItemExt,
@@ -118,6 +148,7 @@ export function createInlineEditorExtensions() {
       transformPastedText: true, // enables markdown parser with escape support
     }),
     DragHandle,
+    ArrowNavigation,
   ]
 }
 

--- a/src/components/editor/__tests__/editor.test.tsx
+++ b/src/components/editor/__tests__/editor.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import type { Editor } from '@tiptap/react'
 import FloatingToolbar from '../FloatingToolbar'
@@ -70,6 +70,43 @@ describe('FloatingToolbar', () => {
     const { container } = render(<FloatingToolbar editor={editor} />)
     const buttons = container.querySelectorAll('button')
     expect(buttons.length).toBeGreaterThan(0)
+  })
+
+  it('activates buttons on Enter', () => {
+    const run = vi.fn()
+    const editor = {
+      isActive: () => false,
+      chain: () => ({
+        focus: () => ({
+          toggleBold: () => ({
+            run,
+          }),
+          toggleItalic: () => ({
+            run: () => true,
+          }),
+          toggleHeading: () => ({
+            run: () => true,
+          }),
+          toggleBulletList: () => ({
+            run: () => true,
+          }),
+          toggleOrderedList: () => ({
+            run: () => true,
+          }),
+          toggleTaskList: () => ({
+            run: () => true,
+          }),
+          toggleBlockquote: () => ({
+            run: () => true,
+          }),
+        }),
+      }),
+    } as unknown as Editor
+
+    const { container } = render(<FloatingToolbar editor={editor} />)
+    const button = container.querySelector('button') as HTMLButtonElement
+    fireEvent.keyDown(button, { key: 'Enter' })
+    expect(run).toHaveBeenCalled()
   })
 })
 


### PR DESCRIPTION
## Summary
- allow moving between blocks with ArrowUp/ArrowDown
- make FloatingToolbar buttons keyboard accessible with Tab/Enter

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5bb3016288327a5f44329cbdd8072