### PR TITLE
Add editor analytics hooks

### DIFF
--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -13,6 +13,7 @@ import { Plugin, PluginKey } from '@tiptap/pm/state'
 import DragHandle from '@tiptap/extension-drag-handle'
 import DOMPurify from 'dompurify'
 import { Extension } from '@tiptap/core'
+import FloatingToolbar from './FloatingToolbar'
 
 export interface InlineEditorProps {
   noteId: string
@@ -163,6 +164,16 @@ export default function InlineEditor({ noteId, markdown, onChange }: InlineEdito
     },
   })
 
+  const [userId, setUserId] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    import('@/lib/supabase-client').then(({ supabaseClient }) => {
+      supabaseClient.auth.getUser().then(({ data }) => {
+        setUserId(data.user?.id ?? null)
+      })
+    })
+  }, [])
+
   React.useEffect(() => {
     if (!editor) return
     const el = editor.view.dom as HTMLElement
@@ -239,6 +250,9 @@ export default function InlineEditor({ noteId, markdown, onChange }: InlineEdito
 
   return (
     <div className="space-y-1">
+      {editor && (
+        <FloatingToolbar editor={editor} noteId={noteId} userId={userId} />
+      )}
       <div className="prose prose-neutral dark:prose-invert max-w-none">
         <EditorContent editor={editor} />
       </div>

--- a/src/components/editor/__tests__/editor.test.tsx
+++ b/src/components/editor/__tests__/editor.test.tsx
@@ -4,6 +4,8 @@ import { describe, expect, it, vi } from 'vitest'
 import type { Editor } from '@tiptap/react'
 import FloatingToolbar from '../FloatingToolbar'
 
+vi.mock('@/lib/analytics', () => ({ track: vi.fn() }))
+
 vi.mock('@tiptap/react', async () => {
   const actual = await vi.importActual<typeof import('@tiptap/react')>(
     '@tiptap/react'
@@ -67,7 +69,9 @@ describe('FloatingToolbar', () => {
       }),
     } as unknown as Editor
 
-    const { container } = render(<FloatingToolbar editor={editor} />)
+    const { container } = render(
+      <FloatingToolbar editor={editor} noteId="note" userId="user" />
+    )
     const buttons = container.querySelectorAll('button')
     expect(buttons.length).toBeGreaterThan(0)
   })
@@ -103,7 +107,9 @@ describe('FloatingToolbar', () => {
       }),
     } as unknown as Editor
 
-    const { container } = render(<FloatingToolbar editor={editor} />)
+    const { container } = render(
+      <FloatingToolbar editor={editor} noteId="note" userId="user" />
+    )
     const button = container.querySelector('button') as HTMLButtonElement
     fireEvent.keyDown(button, { key: 'Enter' })
     expect(run).toHaveBeenCalled()

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,13 @@
+export interface AnalyticsPayload {
+  note_id: string
+  block_id?: string | null
+  user_id?: string | null
+}
+
+export function track(event: string, payload: AnalyticsPayload) {
+  // Placeholder analytics implementation; replace with real provider
+  console.log('analytics event', { event, ...payload })
+}
+const analytics = { track }
+
+export default analytics


### PR DESCRIPTION
## Summary
- add lightweight analytics utility
- track checklist creation and bold clicks with note, block, and user identifiers
- render FloatingToolbar within InlineEditor and fetch user ID on mount

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5be0ab64c8327a2c8057ae7c03fa1