### PR TITLE
Handle invalid initial markdown in InlineEditor

### DIFF
--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -193,8 +193,14 @@ export default function InlineEditor({ noteId, markdown, onChange }: InlineEdito
 
   React.useEffect(() => {
     if (!editor) return
-    const doc = editor.storage.markdown.parse(markdown)
-    editor.commands.setContent(doc)
+    try {
+      const doc = editor.storage.markdown.parser.parse(markdown ?? '')
+      editor.commands.setContent(doc)
+    } catch (err) {
+      console.error(err)
+      const empty = editor.storage.markdown.parser.parse('')
+      editor.commands.setContent(empty)
+    }
   }, [editor, markdown])
 
   const [status, setStatus] = React.useState<SaveStatus>('saved')

--- a/src/components/editor/__tests__/initialContent.test.tsx
+++ b/src/components/editor/__tests__/initialContent.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import InlineEditor from '../InlineEditor'
+
+vi.mock('@/app/actions', () => ({
+  saveNoteInline: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('../FloatingToolbar', () => ({
+  default: () => <div />,
+}))
+
+vi.mock('@/lib/supabase-client', () => ({
+  supabaseClient: { auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null } }) } },
+}))
+
+vi.mock('tippy.js', () => {
+  const tippy = () => ({ destroy: vi.fn() })
+  ;(tippy as unknown as { default: typeof tippy }).default = tippy
+  return tippy
+})
+
+vi.mock('@tiptap/extension-drag-handle', async () => {
+  const actual = await vi.importActual<typeof import('@tiptap/core')>('@tiptap/core')
+  return { default: actual.Extension.create({ name: 'dragHandle' }) }
+})
+
+describe('InlineEditor initialization', () => {
+  const renderEditor = (markdown: string | null) => {
+    expect(() =>
+      render(<InlineEditor noteId="note" markdown={markdown as unknown as string} />),
+    ).not.toThrow()
+  }
+
+  it('initializes with null markdown', () => {
+    renderEditor(null)
+  })
+
+  it('initializes with empty markdown', () => {
+    renderEditor('')
+  })
+
+  it('initializes with invalid markdown', () => {
+    renderEditor('***invalid [markdown')
+  })
+})


### PR DESCRIPTION
## Summary
- guard InlineEditor initial content parsing with try/catch and empty fallback
- test editor initialization with null, empty, and malformed markdown

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5eee604c88327b4132f46e78845b7