### PR TITLE
Handle Supabase import errors in InlineEditor

### DIFF
--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -167,11 +167,17 @@ export default function InlineEditor({ noteId, markdown, onChange }: InlineEdito
   const [userId, setUserId] = React.useState<string | null>(null)
 
   React.useEffect(() => {
-    import('@/lib/supabase-client').then(({ supabaseClient }) => {
-      supabaseClient.auth.getUser().then(({ data }) => {
+    const fetchUser = async () => {
+      try {
+        const { supabaseClient } = await import('@/lib/supabase-client')
+        const { data } = await supabaseClient.auth.getUser()
         setUserId(data.user?.id ?? null)
-      })
-    })
+      } catch (error) {
+        console.warn('Failed to capture user analytics', error)
+      }
+    }
+
+    void fetchUser()
   }, [])
 
   React.useEffect(() => {


### PR DESCRIPTION
## Summary
- avoid failing editor mount when Supabase client import fails
- log a warning if user analytics capture is unavailable

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5ec75590c8327a8fe4f57fc57e7cf