### PR TITLE
Convert HTML note bodies to Markdown on fetch

### DIFF
--- a/scripts/migrate-html-notes.ts
+++ b/scripts/migrate-html-notes.ts
@@ -1,6 +1,5 @@
-import TurndownService from 'turndown'
 import { createClient } from '@supabase/supabase-js'
-import { normalizeTasks } from '../src/lib/markdown'
+import { htmlToMarkdown } from '../src/lib/html'
 
 async function main() {
   const supabaseUrl = process.env.SUPABASE_URL
@@ -24,12 +23,11 @@ async function main() {
     throw error
   }
 
-  const turndown = new TurndownService()
   const updated: string[] = []
 
   for (const note of data ?? []) {
     const html = note.body ?? ''
-    const markdown = normalizeTasks(turndown.turndown(html))
+    const markdown = htmlToMarkdown(html)
     const { error: updateErr } = await supabase
       .from('notes')
       .update({ body: markdown })

--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -2,7 +2,8 @@ export const dynamic = 'force-dynamic'
 
 import { supabaseServer } from '@/lib/supabase-server'
 import { redirect } from 'next/navigation'
-import { deleteNote } from '@/app/actions'
+import { deleteNote, saveNoteInline } from '@/app/actions'
+import { htmlToMarkdown } from '@/lib/html'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import InlineEditor from '@/components/editor/InlineEditor'
@@ -27,6 +28,13 @@ export default async function NotePage({
 
   if (!note) redirect('/notes')
 
+  let body = note.body || ''
+  if (body.includes('<') || body.includes('data-type')) {
+    const markdown = htmlToMarkdown(body)
+    await saveNoteInline(note.id, markdown)
+    body = markdown
+  }
+
   // Capture the id into a serializable primitive for server actions
   const noteId = id
 
@@ -39,7 +47,7 @@ export default async function NotePage({
   return (
     <div className="space-y-4">
       <Input name="title" defaultValue={note.title} className="text-lg font-medium" />
-      <InlineEditor noteId={noteId} markdown={note.body} />
+      <InlineEditor noteId={noteId} markdown={body} />
       <form action={onDelete}>
         <Button type="submit" variant="outline">Delete</Button>
       </form>

--- a/src/lib/__tests__/html.test.ts
+++ b/src/lib/__tests__/html.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest'
+import { htmlToMarkdown } from '../html'
+
+describe('htmlToMarkdown', () => {
+  it('converts simple HTML to Markdown', () => {
+    const html = '<p>Hello</p>'
+    const md = htmlToMarkdown(html)
+    expect(md.trim()).toBe('Hello')
+  })
+})

--- a/src/lib/html.ts
+++ b/src/lib/html.ts
@@ -1,0 +1,8 @@
+import TurndownService from 'turndown'
+import { normalizeTasks } from './markdown'
+
+const turndown = new TurndownService()
+
+export function htmlToMarkdown(html: string) {
+  return normalizeTasks(turndown.turndown(html))
+}


### PR DESCRIPTION
## Summary
- Add `htmlToMarkdown` utility for Turndown-based HTML→Markdown conversion
- Convert and persist HTML note bodies when fetching notes
- Use shared converter in migration script
- Test HTML conversion utility

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6098060e08327bc7c46e2e879b0a8