### PR TITLE
Handle missing note body in InlineEditor

### DIFF
--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -36,10 +36,14 @@ export default async function NotePage({
     redirect('/notes')
   }
 
+  if (note.body == null) {
+    console.warn(`Note ${noteId} has no body`)
+  }
+
   return (
     <div className="space-y-4">
       <Input name="title" defaultValue={note.title} className="text-lg font-medium" />
-      <InlineEditor noteId={noteId} markdown={note.body} />
+      <InlineEditor noteId={noteId} markdown={note.body ?? ''} />
       <form action={onDelete}>
         <Button type="submit" variant="outline">Delete</Button>
       </form>


### PR DESCRIPTION
## Summary
- warn when a note has no body
- default missing note body to empty string for InlineEditor

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6147cf75c8327bf26587fff523f35