### PR TITLE
Warn when note body is missing

### DIFF
--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -28,7 +28,10 @@ export default async function NotePage({
 
   if (!note) redirect('/notes')
 
-  let body = note.body || ''
+  let body = note.body ?? ''
+  if (note.body == null) {
+    console.warn(`Note ${id} has no body`)
+  }
   if (body.includes('<') || body.includes('data-type')) {
     const markdown = htmlToMarkdown(body)
     await saveNoteInline(note.id, markdown)


### PR DESCRIPTION
## Summary
- warn when a note has no body to aid debugging

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6179c071c83278958617fd203fd62