### PR TITLE
feat(editor): lazy-load DOMPurify for pasting

### DIFF
--- a/src/components/editor/__tests__/dragHandle.test.ts
+++ b/src/components/editor/__tests__/dragHandle.test.ts
@@ -4,7 +4,7 @@ import { createInlineEditorExtensions } from '../InlineEditor'
 
 describe('Drag handle extension', () => {
   it('is included in inline editor extensions', () => {
-    const extensions = createInlineEditorExtensions()
+    const { extensions } = createInlineEditorExtensions()
     const names = extensions.map(ext => ext.name)
     expect(names).toContain('dragHandle')
   })

--- a/src/components/editor/__tests__/listItemRules.test.ts
+++ b/src/components/editor/__tests__/listItemRules.test.ts
@@ -4,8 +4,9 @@ import { createInlineEditorExtensions } from '../InlineEditor'
 
 describe('list item input rules', () => {
   it('Enter creates a new list item', () => {
-    const extensions = createInlineEditorExtensions().filter(e => e.name !== 'dragHandle')
-    const editor = new Editor({ extensions })
+    const { extensions } = createInlineEditorExtensions()
+    const filtered = extensions.filter(e => e.name !== 'dragHandle')
+    const editor = new Editor({ extensions: filtered })
 
     editor.commands.toggleBulletList()
     editor.commands.insertContent('one')
@@ -17,8 +18,9 @@ describe('list item input rules', () => {
   })
 
   it('Enter on empty item exits the list', () => {
-    const extensions = createInlineEditorExtensions().filter(e => e.name !== 'dragHandle')
-    const editor = new Editor({ extensions })
+    const { extensions } = createInlineEditorExtensions()
+    const filtered = extensions.filter(e => e.name !== 'dragHandle')
+    const editor = new Editor({ extensions: filtered })
 
     editor.commands.toggleBulletList()
     editor.commands.insertContent('one')
@@ -32,8 +34,9 @@ describe('list item input rules', () => {
   })
 
   it('Backspace at start converts item to paragraph', () => {
-    const extensions = createInlineEditorExtensions().filter(e => e.name !== 'dragHandle')
-    const editor = new Editor({ extensions })
+    const { extensions } = createInlineEditorExtensions()
+    const filtered = extensions.filter(e => e.name !== 'dragHandle')
+    const editor = new Editor({ extensions: filtered })
 
     editor.commands.toggleBulletList()
     editor.commands.insertContent('one')


### PR DESCRIPTION
## Summary
- load DOMPurify only in the browser via a cached dynamic import
- sanitize pasted HTML via async transform and paste handler
- update editor tests for new helper signature

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a61c8748b08327bfc5b8adf4d0a090