### PR TITLE
docs: add note migration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,26 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Operations
+
+### HTML note migration
+
+Whenever a release changes how notes are formatted, run the HTML‑to‑Markdown migration to update existing notes:
+
+```bash
+node --import tsx scripts/migrate-html-notes.ts
+```
+
+Set `SUPABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY` in the environment before running the script.
+
+### Sample note cleanup
+
+After running the migration, remove any leftover sample notes that still match the onboarding content:
+
+```sql
+DELETE FROM notes
+WHERE body = '<sample note body>';
+```
+
+Replace `<sample note body>` with the exact string defined in `src/app/api/init-user/route.ts`.


### PR DESCRIPTION
## Summary
- document running the HTML-to-Markdown migration script after note-formatting releases
- note one-time sample note cleanup SQL

## Testing
- `node --import tsx scripts/migrate-html-notes.ts` *(fails: Missing Supabase credentials)*
- `psql "postgres://localhost/postgres" -c "DELETE FROM notes WHERE body = 'sample';"` *(fails: Connection refused)*
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a62a33e56483278f9c8d643f37f525