### PR TITLE
fix: define metadata base for Next.js

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next'
 import Header from '@/components/Header'
 
 export const metadata: Metadata = {
+  metadataBase: new URL('https://stratella.vercel.app'),
   title: 'Stratella',
   description: 'All your tasks from every note, in one place. Markdown in, clarity out.',
   openGraph: {


### PR DESCRIPTION
## Summary
- add `metadataBase` in app layout to fix warning

## Testing
- `npm test`
- `npm run lint`
- `NEXT_PUBLIC_SUPABASE_URL=http://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a62b9de090832796ce70dc01e2cf6d