### PR TITLE
fix: disable revalidation when converting notes

### DIFF
--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -34,7 +34,7 @@ export default async function NotePage({
   }
   if (body.includes('<') || body.includes('data-type')) {
     const markdown = htmlToMarkdown(body)
-    await saveNoteInline(note.id, markdown)
+    await saveNoteInline(note.id, markdown, { revalidate: false })
     body = markdown
   }
 


### PR DESCRIPTION
## Summary
- call saveNoteInline with `{ revalidate: false }` when converting note body from HTML to markdown

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6501e64448327972f79d68ca6daa6