### PR TITLE
feat(editor): use tiptap-markdown task extensions

### DIFF
--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { saveNoteInline } from '@/app/actions';
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
-import TaskList from '@tiptap/extension-task-list';
 import TaskItem from '@tiptap/extension-task-item';
 import ListItem from '@tiptap/extension-list-item';
 import Placeholder from '@tiptap/extension-placeholder';
@@ -13,6 +12,9 @@ import { Plugin, PluginKey } from '@tiptap/pm/state';
 import DragHandle from '@tiptap/extension-drag-handle';
 import { Extension } from '@tiptap/core';
 import FloatingToolbar from './FloatingToolbar';
+import TaskItemMarkdown from '../../../node_modules/tiptap-markdown/src/extensions/nodes/task-item.js';
+import ListItemMarkdown from '../../../node_modules/tiptap-markdown/src/extensions/nodes/list-item.js';
+import TaskList from './extensions/task-list';
 
 type DOMPurifyType = (typeof import('dompurify'))['default'];
 let DOMPurify: DOMPurifyType | null = null;
@@ -61,6 +63,9 @@ export function saveWithRetry(
 
 export function createInlineEditorExtensions() {
   const TaskItemExt = TaskItem.extend({
+    addStorage() {
+      return TaskItemMarkdown.config.addStorage.call(this);
+    },
     addProseMirrorPlugins() {
       const name = this.name;
       return [
@@ -90,6 +95,9 @@ export function createInlineEditorExtensions() {
   });
 
   const ListItemExt = ListItem.extend({
+    addStorage() {
+      return ListItemMarkdown.config.addStorage.call(this);
+    },
     addKeyboardShortcuts() {
       return {
         ...this.parent?.(),

--- a/src/components/editor/__tests__/markdownStorage.test.ts
+++ b/src/components/editor/__tests__/markdownStorage.test.ts
@@ -1,0 +1,64 @@
+import { Editor } from '@tiptap/core'
+import { createInlineEditorExtensions } from '../InlineEditor'
+import { describe, expect, it } from 'vitest'
+
+function createEditor() {
+  const extensions = createInlineEditorExtensions().filter(
+    (ext) => ext.name !== 'dragHandle',
+  )
+  return new Editor({ extensions })
+}
+
+describe('markdown storage', () => {
+  it('produces markdown for inserted content', () => {
+    const editor = createEditor()
+    editor.commands.insertContent({
+      type: 'heading',
+      attrs: { level: 1 },
+      content: [{ type: 'text', text: 'Heading' }],
+    })
+    editor.commands.insertContent({
+      type: 'bulletList',
+      content: [
+        {
+          type: 'listItem',
+          content: [
+            { type: 'paragraph', content: [{ type: 'text', text: 'Bullet' }] },
+          ],
+        },
+      ],
+    })
+    editor.commands.insertContent({
+      type: 'orderedList',
+      attrs: { start: 1 },
+      content: [
+        {
+          type: 'listItem',
+          content: [
+            { type: 'paragraph', content: [{ type: 'text', text: 'First' }] },
+          ],
+        },
+      ],
+    })
+    editor.commands.insertContent({
+      type: 'taskList',
+      content: [
+        {
+          type: 'taskItem',
+          attrs: { checked: false },
+          content: [
+            { type: 'paragraph', content: [{ type: 'text', text: 'Todo' }] },
+          ],
+        },
+      ],
+    })
+    const md = editor.storage.markdown.getMarkdown()
+    expect(md).toContain('# Heading')
+    expect(md).toContain('- Bullet')
+    expect(md).toContain('1. First')
+    expect(md).toContain('- [ ] Todo')
+    expect(md).not.toMatch(/</)
+    editor.destroy()
+  })
+})
+

--- a/src/components/editor/extensions/task-list.ts
+++ b/src/components/editor/extensions/task-list.ts
@@ -1,0 +1,23 @@
+import TaskListBase from '@tiptap/extension-task-list'
+import taskListPlugin from 'markdown-it-task-lists'
+import BulletList from '../../../../node_modules/tiptap-markdown/src/extensions/nodes/bullet-list.js'
+
+export default TaskListBase.extend({
+  addStorage() {
+    return {
+      markdown: {
+        serialize: BulletList.storage.markdown.serialize,
+        parse: {
+          setup(markdownit) {
+            markdownit.use(taskListPlugin)
+          },
+          updateDOM(element) {
+            ;[...element.querySelectorAll('.contains-task-list')].forEach((list) => {
+              list.setAttribute('data-type', 'taskList')
+            })
+          },
+        },
+      },
+    }
+  },
+})


### PR DESCRIPTION
## Summary
- integrate tiptap-markdown task and list extensions
- ensure custom task behaviors preserve markdown storage
- test markdown serialization for inserted content

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a65a462b7c8327b1365efc04cb9003