### PR TITLE
chore: use tiptap-markdown extensions

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,30 @@
+import path from "path";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  transpilePackages: ["tiptap-markdown"],
+  webpack: (config) => {
+    const base = path.join(
+      path.dirname(require.resolve("tiptap-markdown")),
+      "..",
+    );
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      "tiptap-markdown/src/extensions/nodes/task-item": path.join(
+        base,
+        "src/extensions/nodes/task-item.js",
+      ),
+      "tiptap-markdown/src/extensions/nodes/list-item": path.join(
+        base,
+        "src/extensions/nodes/list-item.js",
+      ),
+      "tiptap-markdown/src/extensions/nodes/bullet-list": path.join(
+        base,
+        "src/extensions/nodes/bullet-list.js",
+      ),
+    };
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/src/components/editor/extensions/task-list.ts
+++ b/src/components/editor/extensions/task-list.ts
@@ -1,0 +1,33 @@
+import { Node } from "@tiptap/core";
+import taskListPlugin from "markdown-it-task-lists";
+import BulletList from "tiptap-markdown/src/extensions/nodes/bullet-list";
+
+const TaskList = Node.create({
+  name: "taskList",
+});
+
+type MarkdownItLike = {
+  use: (...args: unknown[]) => unknown;
+};
+
+export default TaskList.extend({
+  addStorage() {
+    return {
+      markdown: {
+        serialize: BulletList.storage.markdown.serialize,
+        parse: {
+          setup(markdownit: MarkdownItLike) {
+            markdownit.use(taskListPlugin);
+          },
+          updateDOM(element: HTMLElement) {
+            [...element.querySelectorAll(".contains-task-list")].forEach(
+              (list) => {
+                (list as HTMLElement).setAttribute("data-type", "taskList");
+              },
+            );
+          },
+        },
+      },
+    };
+  },
+});

--- a/src/types/tiptap-markdown.d.ts
+++ b/src/types/tiptap-markdown.d.ts
@@ -1,0 +1,22 @@
+declare module "tiptap-markdown/src/extensions/nodes/task-item" {
+  import { Node } from "@tiptap/core";
+  const ext: Node;
+  export default ext;
+}
+
+declare module "tiptap-markdown/src/extensions/nodes/list-item" {
+  import { Node } from "@tiptap/core";
+  const ext: Node;
+  export default ext;
+}
+
+declare module "tiptap-markdown/src/extensions/nodes/bullet-list" {
+  import { Node } from "@tiptap/core";
+  const ext: Node;
+  export default ext;
+}
+
+declare module "markdown-it-task-lists" {
+  const plugin: (md: unknown, opts?: unknown) => unknown;
+  export default plugin;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,14 +1,28 @@
-import { defineConfig } from 'vitest/config'
-import path from 'path'
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+const base = path.join(path.dirname(require.resolve("tiptap-markdown")), "..");
 
 export default defineConfig({
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      "@": path.resolve(__dirname, "./src"),
+      "tiptap-markdown/src/extensions/nodes/task-item": path.join(
+        base,
+        "src/extensions/nodes/task-item.js",
+      ),
+      "tiptap-markdown/src/extensions/nodes/list-item": path.join(
+        base,
+        "src/extensions/nodes/list-item.js",
+      ),
+      "tiptap-markdown/src/extensions/nodes/bullet-list": path.join(
+        base,
+        "src/extensions/nodes/bullet-list.js",
+      ),
     },
   },
   test: {
-    environment: 'jsdom',
+    environment: "jsdom",
     globals: true,
   },
-})
+});


### PR DESCRIPTION
## Summary
- swap inline editor to use tiptap-markdown task and list items
- expose tiptap-markdown node modules through module declarations
- alias tiptap-markdown sources for build and test tooling

## Testing
- `npm run lint`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon NEXT_PUBLIC_POSTHOG_KEY=test NEXT_PUBLIC_POSTHOG_HOST=http://localhost npm run build`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon NEXT_PUBLIC_POSTHOG_KEY=test NEXT_PUBLIC_POSTHOG_HOST=http://localhost npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a65f8243a4832794f1de1dfffbb6fc