### PR TITLE
fix: migrate note html to markdown

### DIFF
--- a/scripts/migrate-note-html.ts
+++ b/scripts/migrate-note-html.ts
@@ -1,0 +1,40 @@
+import { createClient } from '@supabase/supabase-js'
+import { htmlToMarkdown } from '../src/lib/html'
+import { saveNoteInline } from '../src/app/actions'
+
+async function main() {
+  const supabaseUrl = process.env.SUPABASE_URL
+  const supabaseKey =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.SUPABASE_SERVICE_KEY ||
+    process.env.SUPABASE_ANON_KEY
+
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error('Missing Supabase credentials')
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey)
+
+  const { data, error } = await supabase
+    .from('notes')
+    .select('id, body')
+    .or('body.ilike.%<%,body.ilike.%data-type=%')
+
+  if (error) {
+    throw error
+  }
+
+  for (const note of data ?? []) {
+    const body = note.body ?? ''
+    if (/<[a-z][\s\S]*>/i.test(body) || body.includes('data-type')) {
+      const markdown = htmlToMarkdown(body)
+      await saveNoteInline(String(note.id), markdown, { revalidate: false })
+      console.log('Migrated note', note.id)
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -32,7 +32,8 @@ export default async function NotePage({
   if (note.body == null) {
     console.warn(`Note ${id} has no body`)
   }
-  if (body.includes('<') || body.includes('data-type')) {
+  const htmlRegex = /<[a-z][\s\S]*>/i
+  if (htmlRegex.test(body) || body.includes('data-type')) {
     const markdown = htmlToMarkdown(body)
     await saveNoteInline(note.id, markdown, { revalidate: false })
     body = markdown


### PR DESCRIPTION
## Summary
- detect HTML in note bodies via regex and convert to markdown
- add script to migrate existing note HTML to markdown using `saveNoteInline`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6b1cb6e0883278f39578595b56a43