### PR TITLE
refactor: scope editor typography

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -145,3 +145,13 @@ ul[data-type="taskList"] .task-list-item {
   list-style: none;
   @apply flex items-center gap-2 py-1;
 }
+
+.editor-prose :where(p, li) {
+  margin-top: 0;
+  margin-bottom: 0.25rem;
+}
+
+.editor-prose :where(h1, h2, h3, h4, h5, h6) {
+  margin-top: 0.75rem;
+  margin-bottom: 0.25rem;
+}

--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -325,7 +325,7 @@ export default function InlineEditor({
       {editor && (
         <FloatingToolbar editor={editor} noteId={noteId} userId={userId} />
       )}
-      <div className="prose prose-neutral dark:prose-invert max-w-none">
+      <div className="editor-prose prose prose-neutral dark:prose-invert max-w-none">
         <EditorContent editor={editor} />
       </div>
       <div className="text-xs text-muted-foreground text-right h-4">


### PR DESCRIPTION
## Summary
- scope tiptap editor typography with `editor-prose`
- override paragraph, list item, and heading margins

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6b616cd88832796366343640f720e