### PR TITLE
feat: migrate markdown notes to html

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "dompurify": "^3.2.6",
         "jsdom": "^26.1.0",
         "lucide-react": "^0.539.0",
+        "marked": "^15.0.12",
         "next": "15.4.6",
         "posthog-js": "^1.260.1",
         "react": "19.1.0",
@@ -8169,6 +8170,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dompurify": "^3.2.6",
     "jsdom": "^26.1.0",
     "lucide-react": "^0.539.0",
+    "marked": "^15.0.12",
     "next": "15.4.6",
     "posthog-js": "^1.260.1",
     "react": "19.1.0",

--- a/scripts/migrate-notes-to-html.ts
+++ b/scripts/migrate-notes-to-html.ts
@@ -1,0 +1,73 @@
+import { createClient } from "@supabase/supabase-js";
+import { marked } from "marked";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import TaskList from "@tiptap/extension-task-list";
+import TaskItem from "@tiptap/extension-task-item";
+import { JSDOM } from "jsdom";
+
+async function main() {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.SUPABASE_SERVICE_KEY ||
+    process.env.SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error("Missing Supabase credentials");
+  }
+
+  const supabase = createClient(supabaseUrl, supabaseKey);
+
+  const { data, error } = await supabase
+    .from("notes")
+    .select("id, body")
+    .not("body", "ilike", "%<%")
+    .not("body", "ilike", "%data-type=%");
+
+  if (error) {
+    throw error;
+  }
+
+  const dom = new JSDOM("<!doctype html><html><body></body></html>");
+  (global as any).window = dom.window;
+  (global as any).document = dom.window.document;
+  (global as any).DOMParser = dom.window.DOMParser;
+  (global as any).Node = dom.window.Node;
+  (global as any).HTMLElement = dom.window.HTMLElement;
+  (global as any).navigator = dom.window.navigator;
+
+  const editor = new Editor({
+    extensions: [StarterKit, TaskList, TaskItem],
+  });
+
+  const updated: string[] = [];
+
+  for (const note of data ?? []) {
+    const markdown = note.body ?? "";
+    const html = await marked.parse(markdown);
+    editor.commands.setContent(html, false, {
+      parseOptions: { preserveWhitespace: true },
+    });
+    const newHtml = editor.getHTML();
+    const { error: updateErr } = await supabase
+      .from("notes")
+      .update({ body: newHtml })
+      .eq("id", note.id);
+
+    if (updateErr) {
+      console.error("Failed to update note", note.id, updateErr.message);
+    } else {
+      updated.push(String(note.id));
+      console.log("Updated note", note.id);
+    }
+  }
+
+  console.log("Migrated notes:", updated.join(", "));
+  editor.destroy();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add script to migrate markdown note bodies to html via TipTap
- include marked for markdown conversion

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6cae78d3c8327940afea578f4f438