### PR TITLE
Align task list CSS with TipTap and enlarge note title

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -141,9 +141,13 @@ ul[data-type="taskList"] {
   padding-left: 0;
 }
 
-ul[data-type="taskList"] .task-list-item {
-  list-style: none;
+ul[data-type="taskList"] li[data-type="taskItem"] {
   @apply flex items-center gap-2 py-1;
+}
+
+ul[data-type="taskList"] li[data-type="taskItem"] label,
+ul[data-type="taskList"] li[data-type="taskItem"] div {
+  @apply flex items-center;
 }
 
 .editor-prose :where(p, li) {

--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -47,7 +47,7 @@ export default async function NotePage({
       <Input
         name="title"
         defaultValue={note.title}
-        className="text-lg font-medium"
+        className="text-3xl font-bold"
       />
       <InlineEditor noteId={noteId} html={body} />
       <form action={onDelete}>


### PR DESCRIPTION
## Summary
- use TipTap `taskItem` selectors and ensure nested labels/divs flex inline
- apply larger title styling to note title input

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6cd6db0d0832795fc1a0746d5126c