### PR TITLE
Align TipTap task list checkboxes with text

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -142,12 +142,15 @@ ul[data-type="taskList"] {
 }
 
 ul[data-type="taskList"] li[data-type="taskItem"] {
-  @apply flex items-center gap-2 py-1;
+  @apply flex items-start gap-2;
 }
 
-ul[data-type="taskList"] li[data-type="taskItem"] label,
-ul[data-type="taskList"] li[data-type="taskItem"] div {
-  @apply flex items-center;
+ul[data-type="taskList"] li[data-type="taskItem"] > label {
+  @apply flex items-center m-0;
+}
+
+ul[data-type="taskList"] li[data-type="taskItem"] > div {
+  @apply flex-1;
 }
 
 .editor-prose :where(p, li) {


### PR DESCRIPTION
## Summary
- adjust Task List selectors so checkbox and text sit side-by-side
- verify TipTap outputs `<li data-type="taskItem"><label><input/></label><div>...</div></li>`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6d0a15c748327bb43c5451354337d