### PR TITLE
feat: support heading-style note titles

### DIFF
--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -47,7 +47,8 @@ export default async function NotePage({
       <Input
         name="title"
         defaultValue={note.title}
-        className="text-3xl font-bold"
+        variant="title"
+        className="text-3xl md:text-3xl font-bold h-auto py-0"
       />
       <InlineEditor noteId={noteId} html={body} />
       <form action={onDelete}>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,13 +2,18 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+interface InputProps extends React.ComponentProps<"input"> {
+  variant?: "default" | "title"
+}
+
+function Input({ className, type, variant = "default", ...props }: InputProps) {
   return (
     <input
       type={type}
       data-slot="input"
       className={cn(
-        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+        variant === "title" ? null : "h-9 md:text-sm",
         "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
         "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
         className


### PR DESCRIPTION
## Summary
- add optional `title` variant to Input component removing default height and responsive text size
- use `title` variant on note page with heading-sized typography

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Missing environment variable `NEXT_PUBLIC_SUPABASE_URL`)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d2d9262083279666712e66d91a59