### PR TITLE
feat: wrap task list styles in components layer

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -141,16 +141,18 @@ ul[data-type="taskList"] {
   padding-left: 0;
 }
 
-ul[data-type="taskList"] li[data-type="taskItem"] {
-  @apply flex items-start gap-2;
-}
+@layer components {
+  ul[data-type="taskList"] li[data-type="taskItem"] {
+    @apply flex items-start gap-2;
+  }
 
-ul[data-type="taskList"] li[data-type="taskItem"] > label {
-  @apply flex items-center m-0;
-}
+  ul[data-type="taskList"] li[data-type="taskItem"] > label {
+    @apply flex items-center m-0;
+  }
 
-ul[data-type="taskList"] li[data-type="taskItem"] > div {
-  @apply flex-1;
+  ul[data-type="taskList"] li[data-type="taskItem"] > div {
+    @apply flex-1;
+  }
 }
 
 .editor-prose :where(p, li) {


### PR DESCRIPTION
## Summary
- wrap task list item styles in a Tailwind `@layer components` block
- ensure task list CSS applies flexbox to list items, labels, and content

## Testing
- `NEXT_PUBLIC_SUPABASE_URL=http://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy NEXT_PUBLIC_POSTHOG_KEY=dummy NEXT_PUBLIC_POSTHOG_HOST=http://example.com npm run build`
- `node - <<'NODE'
const {JSDOM} = require('jsdom');
const css = `ul[data-type="taskList"] li[data-type="taskItem"]{display:flex;align-items:flex-start;gap:0.5rem}ul[data-type="taskList"] li[data-type="taskItem"]>label{display:flex;align-items:center;margin:0}ul[data-type="taskList"] li[data-type="taskItem"]>div{flex:1}`;
const html = '<ul data-type="taskList"><li data-type="taskItem"><label></label><div>Top</div><ul data-type="taskList"><li data-type="taskItem"><label></label><div>Nested</div></li></ul></li></ul>';
const dom = new JSDOM(`<!DOCTYPE html><head></head><body>${html}</body>`);
const style = dom.window.document.createElement('style');
style.textContent = css;
dom.window.document.head.appendChild(style);
const topLi = dom.window.document.querySelector('ul[data-type="taskList"] > li[data-type="taskItem"]');
const nestedLi = dom.window.document.querySelector('ul[data-type="taskList"] ul[data-type="taskList"] li[data-type="taskItem"]');
console.log('top display:', dom.window.getComputedStyle(topLi).display);
console.log('nested display:', dom.window.getComputedStyle(nestedLi).display);
NODE`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6d8f4df288327885d76265650f653