### PR TITLE
feat: add data-type attribute to task list items

### DIFF
--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -95,6 +95,92 @@ export function createInlineEditorExtensions() {
         }),
       ];
     },
+    addNodeView() {
+      return ({ node, HTMLAttributes, getPos, editor }) => {
+        const listItem = document.createElement("li");
+        const checkboxWrapper = document.createElement("label");
+        const checkboxStyler = document.createElement("span");
+        const checkbox = document.createElement("input");
+        const content = document.createElement("div");
+
+        const updateA11Y = () => {
+          checkbox.ariaLabel =
+            this.options.a11y?.checkboxLabel?.(node, checkbox.checked) ||
+            `Task item checkbox for ${node.textContent || "empty task item"}`;
+        };
+
+        updateA11Y();
+
+        checkboxWrapper.contentEditable = "false";
+        checkbox.type = "checkbox";
+        checkbox.addEventListener("mousedown", (event) =>
+          event.preventDefault(),
+        );
+        checkbox.addEventListener("change", (event) => {
+          if (!editor.isEditable && !this.options.onReadOnlyChecked) {
+            checkbox.checked = !checkbox.checked;
+            return;
+          }
+
+          const { checked } = event.target as HTMLInputElement;
+
+          if (editor.isEditable && typeof getPos === "function") {
+            editor
+              .chain()
+              .focus(undefined, { scrollIntoView: false })
+              .command(({ tr }) => {
+                const position = getPos();
+                if (typeof position !== "number") {
+                  return false;
+                }
+                const currentNode = tr.doc.nodeAt(position);
+                tr.setNodeMarkup(position, undefined, {
+                  ...currentNode?.attrs,
+                  checked,
+                });
+                return true;
+              })
+              .run();
+          }
+
+          if (!editor.isEditable && this.options.onReadOnlyChecked) {
+            if (!this.options.onReadOnlyChecked(node, checked)) {
+              checkbox.checked = !checkbox.checked;
+            }
+          }
+        });
+
+        Object.entries(this.options.HTMLAttributes).forEach(([key, value]) => {
+          listItem.setAttribute(key, value as string);
+        });
+
+        listItem.dataset.checked = node.attrs.checked;
+        checkbox.checked = node.attrs.checked;
+
+        checkboxWrapper.append(checkbox, checkboxStyler);
+
+        listItem.setAttribute("data-type", this.name);
+        listItem.append(checkboxWrapper, content);
+
+        Object.entries(HTMLAttributes).forEach(([key, value]) => {
+          listItem.setAttribute(key, value as string);
+        });
+
+        return {
+          dom: listItem,
+          contentDOM: content,
+          update: (updatedNode) => {
+            if (updatedNode.type !== this.type) {
+              return false;
+            }
+            listItem.dataset.checked = updatedNode.attrs.checked;
+            checkbox.checked = updatedNode.attrs.checked;
+            updateA11Y();
+            return true;
+          },
+        };
+      };
+    },
   });
 
   const ListItemExt = ListItem.extend({

--- a/src/components/editor/__tests__/taskItemDataAttr.test.ts
+++ b/src/components/editor/__tests__/taskItemDataAttr.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { Editor } from "@tiptap/core";
+import { createInlineEditorExtensions } from "../InlineEditor";
+
+describe("task item data-type attribute", () => {
+  it("sets data-type on task list items", () => {
+    const extensions = createInlineEditorExtensions().filter(
+      (e) => e.name !== "dragHandle",
+    );
+    const editor = new Editor({ extensions });
+    editor.commands.toggleTaskList();
+    editor.commands.insertContent("task");
+    const listItem = editor.view.dom.querySelector("li");
+    expect(listItem?.getAttribute("data-type")).toBe("taskItem");
+    editor.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- ensure task item NodeView marks list items with `data-type` for styling
- test that task list items include the expected `data-type` attribute

## Testing
- `npm run lint`
- `npm test`
- `NEXT_PUBLIC_SUPABASE_URL='http://localhost' NEXT_PUBLIC_SUPABASE_ANON_KEY='test' npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6dd06f66c8327ac7d64ce6bd4d00a