### PR TITLE
chore: update task list styles for tiptap

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -140,19 +140,16 @@ ul[data-type="taskList"] {
   list-style: none;
   padding-left: 0;
 }
-
-@layer components {
-  ul[data-type="taskList"] li[data-type="taskItem"] {
-    @apply flex items-start gap-2;
-  }
-
-  ul[data-type="taskList"] li[data-type="taskItem"] > label {
-    @apply flex items-center m-0;
-  }
-
-  ul[data-type="taskList"] li[data-type="taskItem"] > div {
-    @apply flex-1;
-  }
+ul[data-type="taskList"] li[data-type="taskItem"] {
+  display: flex;
+  align-items: center;
+}
+ul[data-type="taskList"] li[data-type="taskItem"] > label {
+  flex: 0 0 auto;
+  margin-right: 0.5rem;
+}
+ul[data-type="taskList"] li[data-type="taskItem"] > div {
+  flex: 1 1 auto;
 }
 
 .editor-prose :where(p, li) {


### PR DESCRIPTION
## Summary
- replace task list styles with Tiptap's canonical snippet
- drop `gap` usage in favor of margin for broader browser support

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: Missing environment variable: NEXT_PUBLIC_SUPABASE_URL)*
- `node <script verifying nested task list styles>`

------
https://chatgpt.com/codex/tasks/task_e_68a6df4000dc83279446a5bad7863bf8