### PR TITLE
feat: extract tasks from html

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -3,7 +3,7 @@ export const dynamic = 'force-dynamic'
 import { supabaseServer } from '@/lib/supabase-server'
 import { redirect } from 'next/navigation'
 import Link from 'next/link'
-import { extractTasks, filterTasks, TaskFilters, TaskWithNote } from '@/lib/taskparse'
+import { extractTasksFromHtml, filterTasks, TaskFilters, TaskWithNote } from '@/lib/taskparse'
 import { toggleTaskFromNote, setTaskDueFromNote } from '@/app/actions'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -24,7 +24,7 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
 
   const tasks: (TaskWithNote & { noteTitle: string })[] = []
   for (const n of notes ?? []) {
-    const todos = extractTasks(n.body)
+    const todos = extractTasksFromHtml(n.body)
     tasks.push(
       ...todos.map(t => ({ ...t, noteId: n.id, noteTitle: n.title || 'Untitled' }))
     )

--- a/src/lib/taskparse.test.ts
+++ b/src/lib/taskparse.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { extractTasks, toggleTaskInMarkdown, filterTasks, TaskWithNote } from './taskparse'
+import {
+  extractTasks,
+  extractTasksFromHtml,
+  toggleTaskInMarkdown,
+  filterTasks,
+  TaskWithNote,
+} from './taskparse'
 
 describe('extractTasks', () => {
   it('finds checked and unchecked tasks', () => {
@@ -53,6 +59,34 @@ describe('extractTasks', () => {
     expect(hit.tags.sort()).toEqual(['home', 'work'])
     expect(hit.status).toBe('waiting')
     expect(hit.text).toBe('task')
+  })
+})
+
+describe('extractTasksFromHtml', () => {
+  it('parses task items and metadata from HTML', () => {
+    const html = `
+      <ul data-type="taskList">
+        <li data-type="taskItem" data-checked="false" data-due="2024-07-01" data-status="waiting" data-tags="home">
+          <label><input type="checkbox"></label>
+          <div>task #work</div>
+        </li>
+        <li data-type="taskItem" data-checked="true">
+          <label><input type="checkbox" checked></label>
+          <div>done tag:home status:done</div>
+        </li>
+      </ul>
+    `
+    const hits = extractTasksFromHtml(html)
+    expect(hits).toHaveLength(2)
+    expect(hits.map(h => h.checked)).toEqual([false, true])
+    const [first, second] = hits
+    expect(first.due).toBe('2024-07-01')
+    expect(first.tags.sort()).toEqual(['home', 'work'])
+    expect(first.status).toBe('waiting')
+    expect(first.text).toBe('task')
+    expect(second.tags).toEqual(['home'])
+    expect(second.status).toBe('done')
+    expect(second.text).toBe('done')
   })
 })
 


### PR DESCRIPTION
## Summary
- add HTML/ProseMirror task extraction and update TaskHit type
- switch tasks page to parse tasks from HTML notes
- cover HTML task parsing with new tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a75399fec4832799baeb70fb181e23