### PR TITLE
refactor: drop tiptap markdown support

### DIFF
--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -6,11 +6,7 @@ import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import TaskList from "@tiptap/extension-task-list";
 import TaskItem from "@tiptap/extension-task-item";
-import ListItem from "@tiptap/extension-list-item";
-import TaskItemMarkdown from "tiptap-markdown/src/extensions/nodes/task-item";
-import ListItemMarkdown from "tiptap-markdown/src/extensions/nodes/list-item";
 import Placeholder from "@tiptap/extension-placeholder";
-import { Markdown } from "tiptap-markdown";
 import { Plugin, PluginKey } from "@tiptap/pm/state";
 import DragHandle from "@tiptap/extension-drag-handle";
 import { Extension } from "@tiptap/core";
@@ -63,12 +59,6 @@ export function saveWithRetry(
 
 export function createInlineEditorExtensions() {
   const TaskItemExt = TaskItem.extend({
-    addStorage() {
-      return {
-        ...this.parent?.(),
-        ...TaskItemMarkdown.storage,
-      };
-    },
     addProseMirrorPlugins() {
       const name = this.name;
       return [
@@ -183,50 +173,6 @@ export function createInlineEditorExtensions() {
     },
   });
 
-  const ListItemExt = ListItem.extend({
-    addStorage() {
-      return {
-        ...this.parent?.(),
-        ...ListItemMarkdown.storage,
-      };
-    },
-    addKeyboardShortcuts() {
-      return {
-        ...this.parent?.(),
-        Enter: () => {
-          if (!this.editor.isActive("listItem")) {
-            return false;
-          }
-
-          const { $from } = this.editor.state.selection;
-          const isEmpty =
-            $from.parent.type.name === "paragraph" &&
-            $from.parent.content.size === 0;
-
-          if (isEmpty) {
-            return this.editor.commands.liftListItem(this.name);
-          }
-
-          return this.editor.commands.splitListItem(this.name);
-        },
-        Backspace: () => {
-          const { selection } = this.editor.state;
-          const { $from, empty } = selection;
-
-          if (
-            !empty ||
-            !$from.parentOffset ||
-            !this.editor.isActive("listItem")
-          ) {
-            return false;
-          }
-
-          return this.editor.commands.liftListItem(this.name);
-        },
-      };
-    },
-  });
-
   const ArrowNavigation = Extension.create({
     addKeyboardShortcuts() {
       return {
@@ -257,15 +203,10 @@ export function createInlineEditorExtensions() {
   });
 
   return [
-    StarterKit.configure({ history: {}, listItem: false }),
-    ListItemExt,
+    StarterKit.configure({ history: {} }),
     TaskList,
     TaskItemExt,
     Placeholder,
-    Markdown.configure({
-      html: false,
-      transformPastedText: true, // enables markdown parser with escape support
-    }),
     DragHandle,
     ArrowNavigation,
   ];

--- a/src/components/editor/__tests__/typingProfile.test.ts
+++ b/src/components/editor/__tests__/typingProfile.test.ts
@@ -1,17 +1,16 @@
-import { describe, expect, it, vi } from 'vitest'
-import { Editor } from '@tiptap/core'
-import StarterKit from '@tiptap/starter-kit'
-import TaskList from '@tiptap/extension-task-list'
-import TaskItem from '@tiptap/extension-task-item'
-import Placeholder from '@tiptap/extension-placeholder'
-import { Markdown } from 'tiptap-markdown'
-const AUTOSAVE_THROTTLE_MS = 3000
+import { describe, expect, it, vi } from "vitest";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import TaskList from "@tiptap/extension-task-list";
+import TaskItem from "@tiptap/extension-task-item";
+import Placeholder from "@tiptap/extension-placeholder";
+const AUTOSAVE_THROTTLE_MS = 3000;
 
-describe('typing performance and autosave', () => {
-  it('handles 10k-word typing with minimal autosaves', () => {
-    vi.useFakeTimers()
-    const saveNoteInline = vi.fn()
-    let saveTimeout: ReturnType<typeof setTimeout> | null = null
+describe("typing performance and autosave", () => {
+  it("handles 10k-word typing with minimal autosaves", () => {
+    vi.useFakeTimers();
+    const saveNoteInline = vi.fn();
+    let saveTimeout: ReturnType<typeof setTimeout> | null = null;
 
     const editor = new Editor({
       extensions: [
@@ -19,34 +18,33 @@ describe('typing performance and autosave', () => {
         TaskList,
         TaskItem,
         Placeholder,
-        Markdown,
       ],
       onUpdate: () => {
-        if (saveTimeout) clearTimeout(saveTimeout)
+        if (saveTimeout) clearTimeout(saveTimeout);
         saveTimeout = setTimeout(() => {
-          saveNoteInline()
-        }, AUTOSAVE_THROTTLE_MS)
+          saveNoteInline();
+        }, AUTOSAVE_THROTTLE_MS);
       },
-    })
+    });
 
-    const words = Array.from({ length: 10000 }, () => 'word')
-    const durations: number[] = []
+    const words = Array.from({ length: 10000 }, () => "word");
+    const durations: number[] = [];
 
     for (let i = 0; i < words.length; i++) {
-      const start = performance.now()
-      editor.commands.insertContent(`${words[i]} `)
-      durations.push(performance.now() - start)
+      const start = performance.now();
+      editor.commands.insertContent(`${words[i]} `);
+      durations.push(performance.now() - start);
       if ((i + 1) % 1000 === 0) {
-        vi.advanceTimersByTime(AUTOSAVE_THROTTLE_MS + 1)
+        vi.advanceTimersByTime(AUTOSAVE_THROTTLE_MS + 1);
       }
     }
 
-    vi.runAllTimers()
+    vi.runAllTimers();
 
-    const avg = durations.reduce((a, b) => a + b, 0) / durations.length
-    expect(avg).toBeLessThan(50)
-    expect(saveNoteInline).toHaveBeenCalledTimes(10)
+    const avg = durations.reduce((a, b) => a + b, 0) / durations.length;
+    expect(avg).toBeLessThan(50);
+    expect(saveNoteInline).toHaveBeenCalledTimes(10);
 
-    vi.useRealTimers()
-  }, 40000)
-})
+    vi.useRealTimers();
+  }, 40000);
+});


### PR DESCRIPTION
## Summary
- remove `tiptap-markdown` imports and Markdown extension from inline editor
- simplify custom extensions and update typing profile test

## Testing
- `npm test`
- `npm run lint`
- `npx prettier -c src/components/editor/InlineEditor.tsx src/components/editor/__tests__/typingProfile.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a755210fa88327a1233acd9a572c0e