### PR TITLE
feat: add legacy HTML migration script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@tiptap/extension-placeholder": "^2.26.1",
         "@tiptap/extension-task-item": "^2.26.1",
         "@tiptap/extension-task-list": "^2.26.1",
+        "@tiptap/html": "^2.26.1",
         "@tiptap/pm": "^2.26.1",
         "@tiptap/react": "^2.26.1",
         "@tiptap/starter-kit": "^2.26.1",
@@ -3586,6 +3587,23 @@
         "@tiptap/core": "^2.7.0"
       }
     },
+    "node_modules/@tiptap/html": {
+      "version": "2.26.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/html/-/html-2.26.1.tgz",
+      "integrity": "sha512-93keIjciRdjgQabxntXBjW6NTrAoM+uC/u3dwoM5CJFs40cpJC+/CEPYG7SJ5Cyv8srv/OqzyjCjoz7PQGvXyA==",
+      "license": "MIT",
+      "dependencies": {
+        "zeed-dom": "^0.15.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^2.7.0",
+        "@tiptap/pm": "^2.7.0"
+      }
+    },
     "node_modules/@tiptap/pm": {
       "version": "2.26.1",
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.26.1.tgz",
@@ -5253,6 +5271,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/cssesc": {
@@ -12174,6 +12204,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zeed-dom": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/zeed-dom/-/zeed-dom-0.15.1.tgz",
+      "integrity": "sha512-dtZ0aQSFyZmoJS0m06/xBN1SazUBPL5HpzlAcs/KcRW0rzadYw12deQBjeMhGKMMeGEp7bA9vmikMLaO4exBcg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-what": "^6.1.0",
+        "entities": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=14.13.1"
+      },
+      "funding": {
+        "type": "GitHub Sponsors ❤",
+        "url": "https://github.com/sponsors/holtwick"
+      }
+    },
+    "node_modules/zeed-dom/node_modules/entities": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-5.0.0.tgz",
+      "integrity": "sha512-BeJFvFRJddxobhvEdm5GqHzRV/X+ACeuw0/BuuxsCh1EUZcAIz8+kYmBp/LrQuloy6K1f3a0M7+IhmZ7QnkISA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "node --import tsx node_modules/vitest/vitest.mjs run"
+    "test": "node --import tsx node_modules/vitest/vitest.mjs run",
+    "migrate:legacy-html": "tsx scripts/migrate-legacy-html.ts"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.2",
@@ -27,6 +28,7 @@
     "@tiptap/extension-task-list": "^2.26.1",
     "@tiptap/pm": "^2.26.1",
     "@tiptap/react": "^2.26.1",
+    "@tiptap/html": "^2.26.1",
     "@tiptap/starter-kit": "^2.26.1",
     "@tiptap/suggestion": "^2.26.1",
     "class-variance-authority": "^0.7.1",

--- a/scripts/migrate-legacy-html.ts
+++ b/scripts/migrate-legacy-html.ts
@@ -1,0 +1,56 @@
+import { createClient } from '@supabase/supabase-js';
+import { generateJSON, generateHTML } from '@tiptap/html';
+import StarterKit from '@tiptap/starter-kit';
+import TaskList from '@tiptap/extension-task-list';
+import TaskItem from '@tiptap/extension-task-item';
+import { JSDOM } from 'jsdom';
+
+const { NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY } = process.env;
+
+if (!NEXT_PUBLIC_SUPABASE_URL || !(SUPABASE_SERVICE_ROLE_KEY || NEXT_PUBLIC_SUPABASE_ANON_KEY)) {
+  console.error('Missing Supabase configuration');
+  process.exit(1);
+}
+
+const supabase = createClient(
+  NEXT_PUBLIC_SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY || NEXT_PUBLIC_SUPABASE_ANON_KEY!
+);
+
+// Provide a DOM environment for TipTap's HTML utilities
+const { window } = new JSDOM('');
+(global as any).window = window;
+(global as any).document = window.document;
+(global as any).DOMParser = window.DOMParser;
+
+const extensions = [StarterKit.configure({ history: {} }), TaskList, TaskItem];
+
+async function migrate() {
+  const { data: notes, error } = await supabase.from('notes').select('id, body');
+  if (error) {
+    console.error('Failed to fetch notes', error);
+    return;
+  }
+
+  for (const note of notes ?? []) {
+    const body = note.body as string | null;
+    if (body && body.includes('<')) {
+      try {
+        const json = generateJSON(body, extensions);
+        const html = generateHTML(json, extensions);
+        await supabase.from('notes').update({ body: html }).eq('id', note.id);
+        console.log(`Migrated note ${note.id}`);
+      } catch (err) {
+        console.error(`Failed to migrate note ${note.id}`, err);
+      }
+    }
+  }
+}
+
+migrate().then(() => {
+  console.log('Migration complete');
+  process.exit(0);
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add script to migrate legacy note HTML to canonical TipTap format
- expose migration via `npm run migrate:legacy-html`
- add `@tiptap/html` dependency

## Testing
- `npm test`
- `npm run lint`
- `npm run migrate:legacy-html` *(fails: Missing Supabase configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a75baf1ddc8327abe0d7fc364371fa