### PR TITLE
Display note metadata and open task count

### DIFF
--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -6,6 +6,7 @@ import { deleteNote } from "@/app/actions";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import InlineEditor from "@/components/editor/InlineEditor";
+import { extractTasksFromHtml } from "@/lib/taskparse";
 
 export default async function NotePage({
   params,
@@ -33,6 +34,14 @@ export default async function NotePage({
     console.warn(`Note ${id} has no body`);
   }
 
+  const openTasks = extractTasksFromHtml(body).filter(t => !t.checked).length;
+  const created = note.created_at
+    ? new Date(note.created_at).toLocaleDateString()
+    : "";
+  const modified = note.updated_at
+    ? new Date(note.updated_at).toLocaleDateString()
+    : "";
+
   // Capture the id into a serializable primitive for server actions
   const noteId = id;
 
@@ -48,8 +57,11 @@ export default async function NotePage({
         name="title"
         defaultValue={note.title}
         variant="title"
-        className="text-3xl md:text-3xl font-bold h-auto py-0"
+        className="text-3xl md:text-3xl font-bold h-auto py-0 border-0 px-0 focus-visible:ring-0"
       />
+      <div className="text-sm text-muted-foreground">
+        Created {created} • Modified {modified} • {openTasks} open tasks
+      </div>
       <InlineEditor noteId={noteId} html={body} />
       <form action={onDelete}>
         <Button type="submit" variant="outline">


### PR DESCRIPTION
## Summary
- show note creation and modification dates
- count and display open tasks from note body
- style note title input without border

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7633563e88327ae8f8a1d7049efa7