### PR TITLE
feat: add NotesList component with view selector

### DIFF
--- a/src/app/notes/NotesList.tsx
+++ b/src/app/notes/NotesList.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { Card, CardContent } from '@/components/ui/card'
+
+type Note = { id: string; title: string | null; updated_at: string }
+
+type View = 'card' | 'grid' | 'list'
+
+export function NotesList({ notes }: { notes: Note[] }) {
+  const [view, setView] = useState<View>('card')
+
+  const gridClass =
+    view === 'card'
+      ? 'grid grid-cols-1 sm:grid-cols-2 gap-3'
+      : 'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3'
+
+  return (
+    <div className="space-y-3">
+      <select
+        value={view}
+        onChange={e => setView(e.target.value as View)}
+        className="h-9 rounded-md border border-input bg-transparent px-2"
+      >
+        <option value="card">Card</option>
+        <option value="grid">Grid</option>
+        <option value="list">List</option>
+      </select>
+
+      {view === 'list' ? (
+        <ul className="divide-y">
+          {notes.map(n => (
+            <li key={n.id}>
+              <Link
+                href={`/notes/${n.id}`}
+                className="flex items-center justify-between py-2"
+              >
+                <span className="font-medium">{n.title || 'Untitled'}</span>
+                <span className="text-xs text-muted-foreground">
+                  Updated {new Date(n.updated_at).toUTCString()}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className={gridClass}>
+          {notes.map(n => (
+            <Link key={n.id} href={`/notes/${n.id}`}>
+              <Card className="hover:bg-accent/30 transition">
+                <CardContent className="p-4">
+                  <div className="font-medium">{n.title || 'Untitled'}</div>
+                  <div className="text-xs text-muted-foreground">
+                    Updated {new Date(n.updated_at).toUTCString()}
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -2,11 +2,10 @@ export const dynamic = 'force-dynamic'
 
 import { supabaseServer } from '@/lib/supabase-server'
 import { redirect } from 'next/navigation'
-import Link from 'next/link'
 import { createNote } from '@/app/actions'
-import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { NotesList } from './NotesList'
 
 export default async function NotesPage() {
   const supabase = await supabaseServer()
@@ -31,20 +30,7 @@ export default async function NotesPage() {
         <Button type="submit">Add</Button>
       </form>
 
-      <div className="grid gap-3">
-        {(notes ?? []).map(n => (
-          <Link key={n.id} href={`/notes/${n.id}`}>
-            <Card className="hover:bg-accent/30 transition">
-              <CardContent className="p-4">
-                <div className="font-medium">{n.title || 'Untitled'}</div>
-                <div className="text-xs text-muted-foreground">
-                  Updated {new Date(n.updated_at).toUTCString()}
-                </div>
-              </CardContent>
-            </Card>
-          </Link>
-        ))}
-      </div>
+      <NotesList notes={notes ?? []} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- extract notes rendering into new client NotesList component
- add view selector to toggle card, grid, or list layouts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a76672c9448327a76b5f2f00ba2061