### PR TITLE
fix: align Sidebar tip punctuation with main

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -33,7 +33,7 @@ export default function Sidebar() {
         </nav>
         <Separator className="my-4" />
         <p className="px-3 text-xs text-muted-foreground">
-          Tip: create tasks by typing [] or by right clicking on highlighted text. These tasks will aggregate in &apos;Tasks&apos;
+          Tip: create tasks by typing [] or by right clicking on highlighted text. These tasks will aggregate in &apos;Tasks&apos;.
         </p>
       </div>
     </aside>


### PR DESCRIPTION
## Summary
- align Sidebar tip punctuation with main

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a76f1632788327a3fcf871a18c8d09