### PR TITLE
feat: add autosaving note title input

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -19,6 +19,17 @@ export async function createNote(title: string) {
   revalidatePath("/notes");
 }
 
+export async function updateNoteTitle(id: string, title: string) {
+  const { supabase, user } = await requireUser();
+  await supabase
+    .from("notes")
+    .update({ title })
+    .eq("id", id)
+    .eq("user_id", user.id);
+  revalidatePath(`/notes/${id}`);
+  revalidatePath("/notes");
+}
+
 export async function saveNote(id: string, title: string, html: string) {
   const { supabase, user } = await requireUser();
   await supabase

--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -4,8 +4,8 @@ import { supabaseServer } from "@/lib/supabase-server";
 import { redirect } from "next/navigation";
 import { deleteNote } from "@/app/actions";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import InlineEditor from "@/components/editor/InlineEditor";
+import NoteTitleInput from "@/components/NoteTitleInput";
 import { extractTasksFromHtml } from "@/lib/taskparse";
 
 export default async function NotePage({
@@ -53,12 +53,7 @@ export default async function NotePage({
 
   return (
     <div className="space-y-4">
-      <Input
-        name="title"
-        defaultValue={note.title}
-        variant="title"
-        className="text-3xl md:text-3xl font-bold h-auto py-0 border-0 px-0 focus-visible:ring-0"
-      />
+        <NoteTitleInput noteId={noteId} initialTitle={note.title} />
       <div className="text-sm text-muted-foreground">
         Created {created} • Modified {modified} • {openTasks} open tasks
       </div>

--- a/src/components/NoteTitleInput.tsx
+++ b/src/components/NoteTitleInput.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import React from 'react'
+import { Input } from '@/components/ui/input'
+import { updateNoteTitle } from '@/app/actions'
+import {
+  AUTOSAVE_THROTTLE_MS,
+  SaveStatus,
+  saveWithRetry,
+} from '@/components/editor/InlineEditor'
+
+interface NoteTitleInputProps {
+  noteId: string
+  initialTitle: string
+}
+
+export default function NoteTitleInput({
+  noteId,
+  initialTitle,
+}: NoteTitleInputProps) {
+  const [title, setTitle] = React.useState(initialTitle)
+  const [status, setStatus] = React.useState<SaveStatus>('saved')
+  const saveTimeout = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const retryTimeout = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const attempts = React.useRef(0)
+
+  const runSave = React.useCallback(
+    (value: string) => {
+      if (retryTimeout.current) {
+        clearTimeout(retryTimeout.current)
+        retryTimeout.current = null
+      }
+      saveWithRetry(
+        () => updateNoteTitle(noteId, value),
+        setStatus,
+        attempts,
+        retryTimeout,
+      )
+    },
+    [noteId],
+  )
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.currentTarget.value
+    setTitle(value)
+    if (saveTimeout.current) clearTimeout(saveTimeout.current)
+    if (retryTimeout.current) {
+      clearTimeout(retryTimeout.current)
+      retryTimeout.current = null
+      attempts.current = 0
+    }
+    setStatus('saving')
+    saveTimeout.current = setTimeout(
+      () => runSave(value),
+      AUTOSAVE_THROTTLE_MS,
+    )
+  }
+
+  const handleBlur = () => {
+    if (saveTimeout.current) clearTimeout(saveTimeout.current)
+    if (retryTimeout.current) {
+      clearTimeout(retryTimeout.current)
+      retryTimeout.current = null
+      attempts.current = 0
+    }
+    runSave(title)
+  }
+
+  React.useEffect(() => {
+    return () => {
+      if (saveTimeout.current) clearTimeout(saveTimeout.current)
+      if (retryTimeout.current) clearTimeout(retryTimeout.current)
+    }
+  }, [])
+
+  return (
+    <div className="space-y-1">
+      <Input
+        name="title"
+        value={title}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        variant="title"
+        className="text-3xl md:text-3xl font-bold h-auto py-0 border-0 px-0 focus-visible:ring-0"
+      />
+      <div className="text-xs text-muted-foreground text-right h-4">
+        {status === 'saving' && 'Saving…'}
+        {status === 'saved' && 'Saved'}
+        {status === 'retrying' && 'Retrying'}
+      </div>
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add `updateNoteTitle` server action to update note titles
- create `NoteTitleInput` client component with debounced saving and status messages
- use `NoteTitleInput` on note page to autosave title changes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a77310b78c832780686dd0b3192a33