### PR TITLE
refactor: ensure note title defaults to string

### DIFF
--- a/src/app/notes/[id]/NoteClient.tsx
+++ b/src/app/notes/[id]/NoteClient.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import React from 'react'
+import NoteTitleInput from '@/components/NoteTitleInput'
+import InlineEditor from '@/components/editor/InlineEditor'
+import { Button } from '@/components/ui/button'
+
+interface NoteClientProps {
+  noteId: string
+  initialTitle: string
+  html: string
+  created: string
+  modified: string
+  openTasks: number
+  onDelete: () => void
+}
+
+export default function NoteClient({
+  noteId,
+  initialTitle,
+  html,
+  created,
+  modified,
+  openTasks,
+  onDelete,
+}: NoteClientProps) {
+  const [title] = React.useState(initialTitle)
+  return (
+    <div className="space-y-4">
+      <NoteTitleInput noteId={noteId} initialTitle={title} />
+      <div className="text-sm text-muted-foreground">
+        Created {created} • Modified {modified} • {openTasks} open tasks
+      </div>
+      <InlineEditor noteId={noteId} html={html} />
+      <form action={onDelete}>
+        <Button type="submit" variant="outline">
+          Delete
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -3,9 +3,7 @@ export const dynamic = "force-dynamic";
 import { supabaseServer } from "@/lib/supabase-server";
 import { redirect } from "next/navigation";
 import { deleteNote } from "@/app/actions";
-import { Button } from "@/components/ui/button";
-import InlineEditor from "@/components/editor/InlineEditor";
-import NoteTitleInput from "@/components/NoteTitleInput";
+import NoteClient from "./NoteClient";
 import { extractTasksFromHtml } from "@/lib/taskparse";
 
 export default async function NotePage({
@@ -52,17 +50,14 @@ export default async function NotePage({
   }
 
   return (
-    <div className="space-y-4">
-        <NoteTitleInput noteId={noteId} initialTitle={note.title} />
-      <div className="text-sm text-muted-foreground">
-        Created {created} • Modified {modified} • {openTasks} open tasks
-      </div>
-      <InlineEditor noteId={noteId} html={body} />
-      <form action={onDelete}>
-        <Button type="submit" variant="outline">
-          Delete
-        </Button>
-      </form>
-    </div>
+    <NoteClient
+      noteId={noteId}
+      initialTitle={note.title ?? ""}
+      html={body}
+      created={created}
+      modified={modified}
+      openTasks={openTasks}
+      onDelete={onDelete}
+    />
   );
 }


### PR DESCRIPTION
## Summary
- Coalesce `note.title` to an empty string before rendering `NoteClient`
- Type `NoteClient`'s `initialTitle` prop as `string` and wire to `<NoteTitleInput>` via state

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a77b4a9f888327b8be39615418eaac