### PR TITLE
Track open task counts on note autosave

### DIFF
--- a/src/app/notes/[id]/NoteClient.tsx
+++ b/src/app/notes/[id]/NoteClient.tsx
@@ -25,13 +25,24 @@ export default function NoteClient({
   onDelete,
 }: NoteClientProps) {
   const [title] = React.useState(initialTitle)
+  const [modifiedState, setModifiedState] = React.useState(modified)
+  const [openTasksState, setOpenTasksState] = React.useState(openTasks)
   return (
     <div className="space-y-4">
       <NoteTitleInput noteId={noteId} initialTitle={title} />
       <div className="text-sm text-muted-foreground">
-        Created {created} • Modified {modified} • {openTasks} open tasks
+        Created {created} • Modified {modifiedState} • {openTasksState} open tasks
       </div>
-      <InlineEditor noteId={noteId} html={html} />
+      <InlineEditor
+        noteId={noteId}
+        html={html}
+        onSaved={({ openTasks, updatedAt }) => {
+          setOpenTasksState(openTasks)
+          if (updatedAt) {
+            setModifiedState(new Date(updatedAt).toLocaleDateString())
+          }
+        }}
+      />
       <form action={onDelete}>
         <Button type="submit" variant="outline">
           Delete

--- a/src/components/editor/__tests__/autosaveOnSaved.test.tsx
+++ b/src/components/editor/__tests__/autosaveOnSaved.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import InlineEditor from "../InlineEditor";
+import { countOpenTasks } from "@/lib/taskparse";
+
+vi.mock("@/app/actions", () => ({
+  saveNoteInline: vi.fn((_: string, html: string) =>
+    Promise.resolve({
+      openTasks: countOpenTasks(html),
+      updatedAt: "2024-01-02T00:00:00.000Z",
+    }),
+  ),
+}));
+
+vi.mock("../FloatingToolbar", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("@/lib/supabase-client", () => ({
+  supabaseClient: {
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null } }) },
+  },
+}));
+
+vi.mock("tippy.js", () => {
+  const tippy = () => ({ destroy: vi.fn() });
+  (tippy as unknown as { default: typeof tippy }).default = tippy;
+  return tippy;
+});
+
+vi.mock("@tiptap/extension-drag-handle", async () => {
+  const actual = await vi.importActual<typeof import("@tiptap/core")>("@tiptap/core");
+  return { default: actual.Extension.create({ name: "dragHandle" }) };
+});
+
+describe("InlineEditor autosave", () => {
+  it("calls onSaved with open task count", async () => {
+    const onSaved = vi.fn();
+    const html = `<ul data-type="taskList"><li data-type="taskItem" data-checked="false"><label><input type="checkbox"></label><div>a</div></li></ul>`;
+    const { container } = render(
+      <InlineEditor noteId="note" html={html} onSaved={onSaved} />,
+    );
+    const editorEl = container.querySelector(".ProseMirror") as HTMLElement;
+    fireEvent.focus(editorEl);
+    fireEvent.blur(editorEl);
+
+    await waitFor(() => expect(onSaved).toHaveBeenCalled());
+    expect(onSaved).toHaveBeenCalledWith({
+      openTasks: 1,
+      updatedAt: "2024-01-02T00:00:00.000Z",
+    });
+  });
+});

--- a/src/components/editor/__tests__/htmlParse.test.tsx
+++ b/src/components/editor/__tests__/htmlParse.test.tsx
@@ -4,7 +4,9 @@ import { describe, expect, it, vi } from "vitest";
 import InlineEditor from "../InlineEditor";
 
 vi.mock("@/app/actions", () => ({
-  saveNoteInline: vi.fn().mockResolvedValue(undefined),
+  saveNoteInline: vi
+    .fn()
+    .mockResolvedValue({ openTasks: 0, updatedAt: null }),
 }));
 
 vi.mock("../FloatingToolbar", () => ({

--- a/src/components/editor/__tests__/initialContent.test.tsx
+++ b/src/components/editor/__tests__/initialContent.test.tsx
@@ -4,7 +4,9 @@ import { describe, expect, it, vi } from "vitest";
 import InlineEditor from "../InlineEditor";
 
 vi.mock("@/app/actions", () => ({
-  saveNoteInline: vi.fn().mockResolvedValue(undefined),
+  saveNoteInline: vi
+    .fn()
+    .mockResolvedValue({ openTasks: 0, updatedAt: null }),
 }));
 
 vi.mock("../FloatingToolbar", () => ({

--- a/src/lib/taskparse.ts
+++ b/src/lib/taskparse.ts
@@ -175,6 +175,10 @@ export function extractTasksFromHtml(html: string | PMNode): TaskHit[] {
   return out
 }
 
+export function countOpenTasks(html: string) {
+  return extractTasksFromHtml(html).filter(t => !t.checked).length
+}
+
 export function toggleTaskInMarkdown(
   md: string,
   hit: TaskHit & { start: number; end: number; mark: string },


### PR DESCRIPTION
## Summary
- add `countOpenTasks` utility to parse HTML for open task totals
- save note body with open task count and return it from `saveNoteInline`
- wire InlineEditor and NoteClient to forward autosave results and update UI
- test that autosave callback receives the correct open task count

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a786bba4048327828bf97be4ddc72a