### PR TITLE
Show open task counts in notes list

### DIFF
--- a/src/app/notes/NotesList.tsx
+++ b/src/app/notes/NotesList.tsx
@@ -3,8 +3,14 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { Card, CardContent } from '@/components/ui/card'
+import { extractTasksFromHtml } from '@/lib/taskparse'
 
-type Note = { id: string; title: string | null; updated_at: string }
+type Note = {
+  id: string
+  title: string | null
+  updated_at: string
+  body: string | null
+}
 
 type View = 'card' | 'grid' | 'list'
 
@@ -30,34 +36,44 @@ export function NotesList({ notes }: { notes: Note[] }) {
 
       {view === 'list' ? (
         <ul className="divide-y">
-          {notes.map(n => (
-            <li key={n.id}>
-              <Link
-                href={`/notes/${n.id}`}
-                className="flex items-center justify-between py-2"
-              >
-                <span className="font-medium">{n.title || 'Untitled'}</span>
-                <span className="text-xs text-muted-foreground">
-                  Updated {new Date(n.updated_at).toUTCString()}
-                </span>
-              </Link>
-            </li>
-          ))}
+          {notes.map(n => {
+            const openTasks = extractTasksFromHtml(n.body || '')
+              .filter(t => !t.checked).length
+            const date = new Date(n.updated_at).toUTCString()
+            return (
+              <li key={n.id}>
+                <Link
+                  href={`/notes/${n.id}`}
+                  className="flex items-center justify-between py-2"
+                >
+                  <span className="font-medium">{n.title || 'Untitled'}</span>
+                  <span className="text-xs text-muted-foreground">
+                    Updated {date} • {openTasks} open tasks
+                  </span>
+                </Link>
+              </li>
+            )
+          })}
         </ul>
       ) : (
         <div className={gridClass}>
-          {notes.map(n => (
-            <Link key={n.id} href={`/notes/${n.id}`}>
-              <Card className="hover:bg-accent/30 transition">
-                <CardContent className="p-4">
-                  <div className="font-medium">{n.title || 'Untitled'}</div>
-                  <div className="text-xs text-muted-foreground">
-                    Updated {new Date(n.updated_at).toUTCString()}
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
-          ))}
+          {notes.map(n => {
+            const openTasks = extractTasksFromHtml(n.body || '')
+              .filter(t => !t.checked).length
+            const date = new Date(n.updated_at).toUTCString()
+            return (
+              <Link key={n.id} href={`/notes/${n.id}`}>
+                <Card className="hover:bg-accent/30 transition">
+                  <CardContent className="p-4">
+                    <div className="font-medium">{n.title || 'Untitled'}</div>
+                    <div className="text-xs text-muted-foreground">
+                      Updated {date} • {openTasks} open tasks
+                    </div>
+                  </CardContent>
+                </Card>
+              </Link>
+            )
+          })}
         </div>
       )}
     </div>

--- a/src/app/notes/NotesList.tsx
+++ b/src/app/notes/NotesList.tsx
@@ -3,13 +3,11 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { Card, CardContent } from '@/components/ui/card'
-import { extractTasksFromHtml } from '@/lib/taskparse'
-
 type Note = {
   id: string
   title: string | null
   updated_at: string
-  body: string | null
+  openTasks: number
 }
 
 type View = 'card' | 'grid' | 'list'
@@ -37,8 +35,6 @@ export function NotesList({ notes }: { notes: Note[] }) {
       {view === 'list' ? (
         <ul className="divide-y">
           {notes.map(n => {
-            const openTasks = extractTasksFromHtml(n.body || '')
-              .filter(t => !t.checked).length
             const date = new Date(n.updated_at).toUTCString()
             return (
               <li key={n.id}>
@@ -48,7 +44,7 @@ export function NotesList({ notes }: { notes: Note[] }) {
                 >
                   <span className="font-medium">{n.title || 'Untitled'}</span>
                   <span className="text-xs text-muted-foreground">
-                    Updated {date} • {openTasks} open tasks
+                    Updated {date} • {n.openTasks} open tasks
                   </span>
                 </Link>
               </li>
@@ -58,8 +54,6 @@ export function NotesList({ notes }: { notes: Note[] }) {
       ) : (
         <div className={gridClass}>
           {notes.map(n => {
-            const openTasks = extractTasksFromHtml(n.body || '')
-              .filter(t => !t.checked).length
             const date = new Date(n.updated_at).toUTCString()
             return (
               <Link key={n.id} href={`/notes/${n.id}`}>
@@ -67,7 +61,7 @@ export function NotesList({ notes }: { notes: Note[] }) {
                   <CardContent className="p-4">
                     <div className="font-medium">{n.title || 'Untitled'}</div>
                     <div className="text-xs text-muted-foreground">
-                      Updated {date} • {openTasks} open tasks
+                      Updated {date} • {n.openTasks} open tasks
                     </div>
                   </CardContent>
                 </Card>

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -6,6 +6,7 @@ import { createNote } from '@/app/actions'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { NotesList } from './NotesList'
+import { countOpenTasks } from '@/lib/taskparse'
 
 export default async function NotesPage() {
   const supabase = await supabaseServer()
@@ -16,6 +17,13 @@ export default async function NotesPage() {
     .from('notes')
     .select('id,title,updated_at,body')
     .order('updated_at', { ascending: false })
+
+  const enriched = (notes ?? []).map(n => ({
+    id: n.id,
+    title: n.title,
+    updated_at: n.updated_at,
+    openTasks: countOpenTasks(n.body || '')
+  }))
 
   async function newNote(formData: FormData) {
     'use server'
@@ -30,7 +38,7 @@ export default async function NotesPage() {
         <Button type="submit">Add</Button>
       </form>
 
-      <NotesList notes={notes ?? []} />
+      <NotesList notes={enriched} />
     </div>
   )
 }

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -14,7 +14,7 @@ export default async function NotesPage() {
 
   const { data: notes } = await supabase
     .from('notes')
-    .select('id,title,updated_at')
+    .select('id,title,updated_at,body')
     .order('updated_at', { ascending: false })
 
   async function newNote(formData: FormData) {


### PR DESCRIPTION
## Summary
- fetch note bodies to compute task counts
- display open task counts and updated date in notes list

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a78ab63b848327a011212e5b59ee70