### PR TITLE
Implement password reset flow and site URL variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 NEXT_PUBLIC_POSTHOG_KEY=phc_your_public_key
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+NEXT_PUBLIC_SITE_URL=https://stratella.vercel.app

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,57 @@
+'use client'
+
+import { FormEvent, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabaseClient } from '@/lib/supabase-client'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+export default function ResetPasswordPage() {
+  const router = useRouter()
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault()
+    setErr(null)
+    setLoading(true)
+    const { error } = await supabaseClient.auth.updateUser({ password })
+    setLoading(false)
+    if (error) setErr(error.message)
+    else router.replace('/login')
+  }
+
+  return (
+    <div className="min-h-[calc(100dvh-3.5rem)] grid place-items-center px-4">
+      <Card className="w-full max-w-sm">
+        <CardHeader>
+          <CardTitle className="text-lg">Reset password</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={onSubmit} className="space-y-4">
+            <div className="grid gap-2">
+              <Label htmlFor="password">New password</Label>
+              <Input
+                id="password"
+                type="password"
+                placeholder="••••••••"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                autoComplete="new-password"
+                required
+              />
+            </div>
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? 'Updating…' : 'Update password'}
+            </Button>
+            {err && <p className="text-sm text-destructive text-center">{err}</p>}
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -84,7 +84,9 @@ export default function SignInForm() {
       setErr('Enter your email above first.')
       return
     }
-    const redirectTo = `${window.location.origin}/login`
+    const redirectTo = `${
+      process.env.NEXT_PUBLIC_SITE_URL ?? window.location.origin
+    }/reset-password`
     const { error } = await supabaseClient.auth.resetPasswordForEmail(email, { redirectTo })
     if (error) setErr(error.message)
     else setMsg('Reset email sent — check your inbox.')


### PR DESCRIPTION
## Summary
- add NEXT_PUBLIC_SITE_URL env var for base URL configuration
- create reset-password page to update user password and redirect to login
- use NEXT_PUBLIC_SITE_URL in SignInForm reset email link

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a79d5c351c8327b2d990b0778eb4d6