### PR TITLE
Add open_tasks column and improve note saving error handling

### DIFF
--- a/supabase/migrations/20250222000000_add_open_tasks_to_notes.sql
+++ b/supabase/migrations/20250222000000_add_open_tasks_to_notes.sql
@@ -1,0 +1,2 @@
+-- Add open_tasks column to notes table
+ALTER TABLE notes ADD COLUMN open_tasks numeric DEFAULT 0;


### PR DESCRIPTION
## Summary
- add migration for `open_tasks` column on `notes`
- surface Supabase errors in `saveNoteInline` and guard `open_tasks` update

## Testing
- `npx prettier --write src/app/actions.ts supabase/migrations/20250222000000_add_open_tasks_to_notes.sql` *(fails: No parser for SQL)*
- `npx prettier --write src/app/actions.ts`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7bed94b988327b1522ef744fb3230