### PR TITLE
feat: add mobile back button

### DIFF
--- a/src/app/notes/[id]/NoteClient.tsx
+++ b/src/app/notes/[id]/NoteClient.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import NoteTitleInput from '@/components/NoteTitleInput'
 import InlineEditor from '@/components/editor/InlineEditor'
 import { Button } from '@/components/ui/button'
+import BackButton from '@/components/BackButton'
 
 interface NoteClientProps {
   noteId: string
@@ -29,6 +30,7 @@ export default function NoteClient({
   const [openTasksState, setOpenTasksState] = React.useState(openTasks)
   return (
     <div className="space-y-4 relative z-0">
+      <BackButton href="/notes" />
       <NoteTitleInput noteId={noteId} initialTitle={title} />
       <div className="text-sm text-muted-foreground">
         Created {created} • Modified {modifiedState} • {openTasksState} open tasks

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import React from 'react'
+import { useRouter } from 'next/navigation'
+import { ArrowLeft } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+
+interface BackButtonProps {
+  href?: string
+  className?: string
+}
+
+export default function BackButton({ href = '/', className }: BackButtonProps) {
+  const router = useRouter()
+  const handleClick = React.useCallback(() => {
+    router.push(href)
+  }, [router, href])
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={handleClick}
+      aria-label="Go back"
+      className={cn('md:hidden', className)}
+    >
+      <ArrowLeft className="h-5 w-5" />
+    </Button>
+  )
+}
+

--- a/src/components/__tests__/BackButton.test.tsx
+++ b/src/components/__tests__/BackButton.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const push = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push }),
+}))
+
+import BackButton from '../BackButton'
+
+describe('BackButton', () => {
+  beforeEach(() => {
+    push.mockClear()
+  })
+
+  function setUserAgent(ua: string) {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: ua,
+      configurable: true,
+      writable: true,
+    })
+  }
+
+  it('navigates on iOS', () => {
+    setUserAgent('Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X)')
+    const { getByRole } = render(<BackButton href="/notes" />)
+    fireEvent.click(getByRole('button', { name: /go back/i }))
+    expect(push).toHaveBeenCalledWith('/notes')
+  })
+
+  it('navigates on Android', () => {
+    setUserAgent('Mozilla/5.0 (Linux; Android 10)')
+    const { getByRole } = render(<BackButton href="/notes" />)
+    fireEvent.click(getByRole('button', { name: /go back/i }))
+    expect(push).toHaveBeenCalledWith('/notes')
+  })
+})
+


### PR DESCRIPTION
## Summary
- add reusable BackButton component with ArrowLeft icon
- integrate BackButton into NoteClient before NoteTitleInput
- test iOS and Android navigation behaviour

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa344baf6883278469c52ff5f2505c