### PR TITLE
feat: add Tailwind component utilities

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -161,3 +161,21 @@ ul[data-type="taskList"] li[data-type="taskItem"] > div {
   margin-top: 0.75rem;
   margin-bottom: 0.25rem;
 }
+
+@layer components {
+  .btn-neutral {
+    @apply inline-flex items-center justify-center rounded-md bg-secondary px-4 py-2 text-sm font-medium text-secondary-foreground shadow-sm transition-colors hover:bg-secondary/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50;
+  }
+  .btn-primary {
+    @apply inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50;
+  }
+  .pill {
+    @apply inline-flex items-center gap-1 rounded-full bg-secondary px-2.5 py-0.5 text-xs font-semibold text-secondary-foreground;
+  }
+  .card {
+    @apply rounded-lg border bg-card p-4 text-card-foreground shadow-sm;
+  }
+  .select-trigger {
+    @apply flex h-8 w-full items-center justify-between rounded-md border border-input bg-transparent px-2 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50;
+  }
+}


### PR DESCRIPTION
## Summary
- add `@layer components` block for shared `.btn-neutral`, `.btn-primary`, `.pill`, `.card`, and `.select-trigger` utilities

## Testing
- `npx @tailwindcss/cli -i ./src/app/globals.css -o /tmp/tailwind.css`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ae3613280c83278aa498a1e6bffac4