### PR TITLE
feat: add tasks filters overlay

### DIFF
--- a/src/components/tasks/FiltersOverlay.tsx
+++ b/src/components/tasks/FiltersOverlay.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { Button } from "@/components/ui/button";
+import DateFilterTrigger from "./DateFilterTrigger";
+import type { TaskFilters } from "@/lib/taskparse";
+
+interface NoteOption {
+  id: string;
+  title: string;
+}
+
+interface FilterState extends TaskFilters {
+  note?: string;
+}
+
+interface FiltersOverlayProps {
+  open: boolean;
+  onClose: () => void;
+  notes: NoteOption[];
+  tags: string[];
+  initialFilters?: FilterState;
+  onApply: (filters: FilterState) => void;
+}
+
+export default function FiltersOverlay({
+  open,
+  onClose,
+  notes,
+  tags,
+  initialFilters,
+  onApply,
+}: FiltersOverlayProps) {
+  const [filters, setFilters] = useState<FilterState>(
+    () => initialFilters ?? {},
+  );
+
+  useEffect(() => {
+    if (open) {
+      setFilters(initialFilters ?? {});
+    }
+  }, [open, initialFilters]);
+
+  function update(patch: Partial<FilterState>) {
+    setFilters((f) => ({ ...f, ...patch }));
+  }
+
+  function handleApply() {
+    onApply(filters);
+    onClose();
+  }
+
+  function handleClearAll() {
+    const empty: FilterState = {};
+    setFilters(empty);
+    onApply(empty);
+    onClose();
+  }
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) onClose();
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
+        <Dialog.Content
+          role="dialog"
+          className="fixed inset-0 z-50 flex flex-col bg-background p-4"
+        >
+          <div className="flex flex-col gap-4 overflow-auto">
+            <select
+              value={filters.completion ?? ""}
+              onChange={(e) =>
+                update({ completion: e.target.value || undefined })
+              }
+              className="h-9 rounded-md border border-input bg-transparent px-2"
+            >
+              <option value="">All</option>
+              <option value="open">Open</option>
+              <option value="done">Done</option>
+            </select>
+            <select
+              value={filters.note ?? ""}
+              onChange={(e) => update({ note: e.target.value || undefined })}
+              className="h-9 rounded-md border border-input bg-transparent px-2"
+            >
+              <option value="">All Notes</option>
+              {notes.map((n) => (
+                <option key={n.id} value={n.id}>
+                  {n.title || "Untitled"}
+                </option>
+              ))}
+            </select>
+            <select
+              value={filters.tag ?? ""}
+              onChange={(e) => update({ tag: e.target.value || undefined })}
+              className="h-9 rounded-md border border-input bg-transparent px-2"
+            >
+              <option value="">All Tags</option>
+              {tags.map((tag) => (
+                <option key={tag} value={tag}>
+                  {tag}
+                </option>
+              ))}
+            </select>
+            <DateFilterTrigger
+              value={filters.due}
+              onChange={(d) => update({ due: d })}
+              onClear={() => update({ due: undefined })}
+            />
+            <select
+              value={filters.sort ?? ""}
+              onChange={(e) => update({ sort: e.target.value || undefined })}
+              className="h-9 rounded-md border border-input bg-transparent px-2"
+            >
+              <option value="">Sort</option>
+              <option value="due">Due</option>
+              <option value="text">Text</option>
+            </select>
+          </div>
+          <div className="mt-auto flex justify-end gap-2 pt-4">
+            <Button type="button" onClick={handleApply}>
+              Apply
+            </Button>
+            <Button type="button" variant="ghost" onClick={handleClearAll}>
+              Clear all
+            </Button>
+            <Button type="button" variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}


### PR DESCRIPTION
## Summary
- add FiltersOverlay component for applying task filters in a modal dialog
- include completion, note, tag, due date and sort options with footer actions

## Testing
- `npm test`
- `npm run lint`
- `npx prettier --check src/components/tasks/FiltersOverlay.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ae3ec1ff108327b118ed274bfcc4d8