### PR TITLE
Use TaskRow server actions

### DIFF
--- a/src/components/tasks/TaskRow.tsx
+++ b/src/components/tasks/TaskRow.tsx
@@ -12,8 +12,8 @@ interface Task {
 
 interface TaskRowProps {
   task: Task
-  onToggle: (done: boolean) => void
-  onDueChange: (value: string) => void
+  onToggle: (done: boolean) => void | Promise<void>
+  onDueChange: (value: string) => void | Promise<void>
 }
 
 export default function TaskRow({ task, onToggle, onDueChange }: TaskRowProps) {


### PR DESCRIPTION
## Summary
- refactor tasks page to use `TaskRow` with server actions
- allow TaskRow callbacks to be async

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Missing environment variable: NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68ae47bd97d48327bc78ad05bd5418a6