### PR TITLE
test: add tasks filter tests

### DIFF
--- a/src/components/tasks/__tests__/TasksFilterBar.test.tsx
+++ b/src/components/tasks/__tests__/TasksFilterBar.test.tsx
@@ -1,13 +1,18 @@
 import React from "react";
-(globalThis as any).React = React;
+(globalThis as unknown as { React: typeof React }).React = React;
 import { fireEvent, render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 const params = new URLSearchParams();
 vi.mock("next/navigation", () => ({
   useSearchParams: () => params,
 }));
+interface DateFilterProps {
+  onChange: (date: string | undefined) => void;
+  value?: string;
+  onClear: () => void;
+}
 vi.mock("../DateFilterTrigger", () => ({
-  default: ({ onChange, value, onClear }: any) => (
+  default: ({ onChange, value, onClear }: DateFilterProps) => (
     <div>
       <button onClick={() => onChange("2024-01-01")}>set-date</button>
       {value && <button onClick={onClear}>clear-date</button>}

--- a/src/components/tasks/__tests__/TasksFilters.test.tsx
+++ b/src/components/tasks/__tests__/TasksFilters.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-(globalThis as any).React = React;
+(globalThis as unknown as { React: typeof React }).React = React;
 import { fireEvent, render, screen } from "@testing-library/react";
 import { vi } from "vitest";
 const pushMock = vi.fn();


### PR DESCRIPTION
## Summary
- add coverage for TasksFilters overlay activation and URL updates
- test TasksFilterBar filter controls and pill display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae4fe14a1c8327843646df3c29a03c