### PR TITLE
feat: add task filter analytics

### DIFF
--- a/src/components/tasks/DateFilterTrigger.tsx
+++ b/src/components/tasks/DateFilterTrigger.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from 'react'
 import { Button } from '@/components/ui/button'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { track } from '@/lib/analytics'
 
 export interface DateFilterTriggerProps {
   value?: string
@@ -25,6 +26,7 @@ export default function DateFilterTrigger({ value, onChange, onClear }: DateFilt
   const handleSelect = useCallback(
     (d: Date) => {
       onChange(format(d))
+      track('tasks.datepicker.date_set', { note_id: 'tasks' })
       setOpen(false)
     },
     [onChange]
@@ -56,6 +58,7 @@ export default function DateFilterTrigger({ value, onChange, onClear }: DateFilt
 
   function handleClear() {
     onClear?.()
+    track('tasks.datepicker.cleared', { note_id: 'tasks' })
     setOpen(false)
   }
 
@@ -73,7 +76,17 @@ export default function DateFilterTrigger({ value, onChange, onClear }: DateFilt
 
   return (
     <div className="relative inline-block">
-      <Button type="button" variant="outline" onClick={() => setOpen(o => !o)}>
+      <Button
+        type="button"
+        variant="outline"
+        onClick={() =>
+          setOpen(o => {
+            const next = !o
+            if (next) track('tasks.datepicker.opened', { note_id: 'tasks' })
+            return next
+          })
+        }
+      >
         {value || 'Select date'}
       </Button>
       {open && (

--- a/src/components/tasks/FiltersOverlay.tsx
+++ b/src/components/tasks/FiltersOverlay.tsx
@@ -5,6 +5,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { Button } from "@/components/ui/button";
 import DateFilterTrigger from "./DateFilterTrigger";
 import type { TaskFilters } from "@/lib/taskparse";
+import { track } from "@/lib/analytics";
 
 interface NoteOption {
   id: string;
@@ -44,10 +45,12 @@ export default function FiltersOverlay({
 
   function update(patch: Partial<FilterState>) {
     setFilters((f) => ({ ...f, ...patch }));
+    track('tasks.filters.changed', { note_id: 'tasks' });
   }
 
   function handleApply() {
     onApply(filters);
+    track('tasks.filters.applied', { note_id: 'tasks' });
     onClose();
   }
 
@@ -55,6 +58,7 @@ export default function FiltersOverlay({
     const empty: FilterState = {};
     setFilters(empty);
     onApply(empty);
+    track('tasks.filters.cleared', { note_id: 'tasks' });
     onClose();
   }
 
@@ -110,7 +114,10 @@ export default function FiltersOverlay({
             <DateFilterTrigger
               value={filters.due}
               onChange={(d) => update({ due: d })}
-              onClear={() => update({ due: undefined })}
+              onClear={() => {
+                update({ due: undefined });
+                track('tasks.filters.cleared', { note_id: 'tasks' });
+              }}
             />
             <select
               value={filters.sort ?? ""}

--- a/src/components/tasks/TasksFilterBar.tsx
+++ b/src/components/tasks/TasksFilterBar.tsx
@@ -6,6 +6,7 @@ import DateFilterTrigger from './DateFilterTrigger'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import type { TaskFilters } from '@/lib/taskparse'
+import { track } from '@/lib/analytics'
 
 interface NoteOption {
   id: string
@@ -49,10 +50,17 @@ export default function TasksFilterBar({ notes, tags, onChange, onApply }: Tasks
 
   function update(patch: Partial<FilterState>) {
     setFilters(f => ({ ...f, ...patch }))
+    track('tasks.filters.changed', { note_id: 'tasks' })
   }
 
   function clear(key: keyof FilterState) {
     update({ [key]: undefined })
+    track('tasks.filters.cleared', { note_id: 'tasks' })
+  }
+
+  function handleApply() {
+    onApply?.(filters)
+    track('tasks.filters.applied', { note_id: 'tasks' })
   }
 
   const pills: { key: keyof FilterState; label: string }[] = []
@@ -119,7 +127,7 @@ export default function TasksFilterBar({ notes, tags, onChange, onApply }: Tasks
           <option value="text">Text</option>
         </select>
         {onApply && (
-          <Button type="button" onClick={() => onApply(filters)}>
+          <Button type="button" onClick={handleApply}>
             Apply
           </Button>
         )}


### PR DESCRIPTION
## Summary
- track task filter interactions including change, apply, and clear
- log datepicker open, set, and clear events
- wire up analytics for filter overlay

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6ac4dd6d4832790e8f2d2b8ef163a