### PR TITLE
feat: add reusable ViewSelector

### DIFF
--- a/src/app/notes/NotesList.tsx
+++ b/src/app/notes/NotesList.tsx
@@ -1,7 +1,9 @@
 'use client'
 
-import { useState } from 'react'
 import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { LayoutPanelTop, LayoutGrid, List } from 'lucide-react'
+import ViewSelector from '@/components/ViewSelector'
 import { Card, CardContent } from '@/components/ui/card'
 type Note = {
   id: string
@@ -13,7 +15,8 @@ type Note = {
 type View = 'card' | 'grid' | 'list'
 
 export function NotesList({ notes }: { notes: Note[] }) {
-  const [view, setView] = useState<View>('card')
+  const params = useSearchParams()
+  const view = (params.get('view') as View) ?? 'card'
 
   const gridClass =
     view === 'card'
@@ -22,15 +25,14 @@ export function NotesList({ notes }: { notes: Note[] }) {
 
   return (
     <div className="space-y-3">
-      <select
-        value={view}
-        onChange={e => setView(e.target.value as View)}
-        className="h-9 rounded-md border border-input bg-transparent px-2"
-      >
-        <option value="card">Card</option>
-        <option value="grid">Grid</option>
-        <option value="list">List</option>
-      </select>
+      <ViewSelector
+        defaultValue="card"
+        options={[
+          { value: 'card', label: 'Card', icon: LayoutPanelTop },
+          { value: 'grid', label: 'Grid', icon: LayoutGrid },
+          { value: 'list', label: 'List', icon: List },
+        ]}
+      />
 
       {view === 'list' ? (
         <ul className="divide-y">

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -9,6 +9,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import TaskRow from '@/components/tasks/TaskRow'
+import ViewSelector from '@/components/ViewSelector'
+import { LayoutPanelTop, List as ListIcon } from 'lucide-react'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function handleToggle(noteId: string, line: number, _done: boolean) {
@@ -46,6 +48,9 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
   const params = await searchParams
 
   const noteId = typeof params.note === 'string' ? params.note : undefined
+
+  const viewParam = typeof params.view === 'string' ? params.view : undefined
+  const view = viewParam === 'card' ? 'card' : 'list'
 
   const filters: TaskFilters = {
     completion: typeof params.completion === 'string' ? params.completion : undefined,
@@ -130,8 +135,46 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
             </select>
             <Button type="submit">Apply</Button>
           </form>
+          <ViewSelector
+            defaultValue="list"
+            options={[
+              { value: 'list', label: 'List', icon: ListIcon },
+              { value: 'card', label: 'Card', icon: LayoutPanelTop },
+            ]}
+            className="mb-4"
+          />
           {groups.length === 0 ? (
             <p className="text-muted-foreground">{emptyMessage}</p>
+          ) : view === 'card' ? (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {groups.map(group => (
+                <Card key={group.id}>
+                  <CardHeader>
+                    <CardTitle>
+                      <NavButton
+                        href={`/notes/${group.id}`}
+                        variant="link"
+                        className="p-0 h-auto font-medium underline"
+                      >
+                        {group.title}
+                      </NavButton>
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <ul className="space-y-2">
+                      {group.tasks.map(t => (
+                        <TaskRow
+                          key={t.line}
+                          task={{ title: t.text, done: t.checked, due: t.due }}
+                          onToggle={handleToggle.bind(null, group.id, t.line)}
+                          onDueChange={handleDueChange.bind(null, group.id, t.line)}
+                        />
+                      ))}
+                    </ul>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
           ) : (
             <div className="space-y-6">
               {groups.map(group => (

--- a/src/components/ViewSelector.tsx
+++ b/src/components/ViewSelector.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { LucideIcon } from 'lucide-react'
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+import { cn } from '@/lib/utils'
+
+export type ViewOption = {
+  value: string
+  label: string
+  icon: LucideIcon
+}
+
+interface ViewSelectorProps {
+  options: ViewOption[]
+  paramKey?: string
+  defaultValue: string
+  className?: string
+}
+
+export function ViewSelector({ options, paramKey = 'view', defaultValue, className }: ViewSelectorProps) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  const current = searchParams.get(paramKey) ?? defaultValue
+
+  function handleClick(value: string) {
+    const params = new URLSearchParams(searchParams.toString())
+    params.set(paramKey, value)
+    router.replace(`${pathname}?${params.toString()}`)
+  }
+
+  return (
+    <div
+      className={cn(
+        'inline-flex h-9 divide-x rounded-md border border-input bg-background overflow-hidden',
+        className
+      )}
+    >
+      {options.map(opt => {
+        const Icon = opt.icon
+        const active = current === opt.value
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => handleClick(opt.value)}
+            className={cn(
+              'flex items-center gap-1.5 px-3 text-sm transition-colors',
+              active
+                ? 'bg-accent text-accent-foreground'
+                : 'hover:bg-accent/50'
+            )}
+            aria-pressed={active}
+          >
+            <Icon className="size-4" />
+            <span>{opt.label}</span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+export default ViewSelector
+

--- a/src/components/__tests__/ViewSelector.test.tsx
+++ b/src/components/__tests__/ViewSelector.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+;(globalThis as unknown as { React: typeof React }).React = React
+import { render, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const replace = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace }),
+  usePathname: () => '/notes',
+  useSearchParams: () => new URLSearchParams('foo=bar&view=card'),
+}))
+
+import ViewSelector from '../ViewSelector'
+import { LayoutPanelTop, List } from 'lucide-react'
+
+describe('ViewSelector', () => {
+  beforeEach(() => replace.mockClear())
+
+  it('updates the view query parameter', () => {
+    const { getByText } = render(
+      <ViewSelector
+        defaultValue="card"
+        options={[
+          { value: 'card', label: 'Card', icon: LayoutPanelTop },
+          { value: 'list', label: 'List', icon: List },
+        ]}
+      />
+    )
+
+    fireEvent.click(getByText('List'))
+    expect(replace).toHaveBeenCalledWith('/notes?foo=bar&view=list')
+  })
+})
+


### PR DESCRIPTION
## Summary
- add segmented ViewSelector component backed by URL params
- use ViewSelector on notes list for card, grid, and list layouts
- enable list and card views for tasks page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6b959ffe88327ba2fad110997f8e4