### PR TITLE
feat: add notes filter bar

### DIFF
--- a/src/app/notes/NotesClient.tsx
+++ b/src/app/notes/NotesClient.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import ViewSelector from '@/components/ViewSelector'
+import FilterBar, { NoteFilters } from '@/components/notes/FilterBar'
+import { Filter, LayoutPanelTop, LayoutGrid, List } from 'lucide-react'
+import { NotesList, type Note } from './NotesList'
+
+export function NotesClient({ notes }: { notes: Note[] }) {
+  const [showFilters, setShowFilters] = useState(false)
+  const [filters, setFilters] = useState<NoteFilters>({ sort: 'newest' })
+
+  const filtered = useMemo(() => {
+    let res = [...notes]
+    if (filters.search) {
+      const s = filters.search.toLowerCase()
+      res = res.filter(n => n.title?.toLowerCase().includes(s))
+    }
+    res.sort((a, b) => {
+      const diff = new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime()
+      return filters.sort === 'oldest' ? diff : -diff
+    })
+    return res
+  }, [notes, filters])
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <ViewSelector
+          defaultValue="card"
+          options={[
+            { value: 'card', label: 'Card', icon: LayoutPanelTop },
+            { value: 'grid', label: 'Grid', icon: LayoutGrid },
+            { value: 'list', label: 'List', icon: List },
+          ]}
+        />
+        <button
+          type="button"
+          aria-label="Toggle filters"
+          onClick={() => setShowFilters(s => !s)}
+          className="rounded-md border border-input p-2 hover:bg-accent/50"
+        >
+          <Filter className="size-4" />
+        </button>
+      </div>
+      {showFilters && <FilterBar onChange={setFilters} />}
+      <NotesList notes={filtered} />
+    </div>
+  )
+}
+

--- a/src/app/notes/NotesList.tsx
+++ b/src/app/notes/NotesList.tsx
@@ -2,10 +2,8 @@
 
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
-import { LayoutPanelTop, LayoutGrid, List } from 'lucide-react'
-import ViewSelector from '@/components/ViewSelector'
 import { Card, CardContent } from '@/components/ui/card'
-type Note = {
+export type Note = {
   id: string
   title: string | null
   updated_at: string
@@ -23,55 +21,42 @@ export function NotesList({ notes }: { notes: Note[] }) {
       ? 'grid grid-cols-1 sm:grid-cols-2 gap-3'
       : 'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3 auto-rows-fr'
 
-  return (
-    <div className="space-y-3">
-      <ViewSelector
-        defaultValue="card"
-        options={[
-          { value: 'card', label: 'Card', icon: LayoutPanelTop },
-          { value: 'grid', label: 'Grid', icon: LayoutGrid },
-          { value: 'list', label: 'List', icon: List },
-        ]}
-      />
-
-      {view === 'list' ? (
-        <ul className="divide-y">
-          {notes.map(n => {
-            const date = new Date(n.updated_at).toUTCString()
-            return (
-              <li key={n.id}>
-                <Link
-                  href={`/notes/${n.id}`}
-                  className="flex items-center justify-between py-2"
-                >
-                  <span className="font-medium">{n.title || 'Untitled'}</span>
-                  <span className="text-xs text-muted-foreground">
-                    Updated {date} • {n.openTasks} open tasks
-                  </span>
-                </Link>
-              </li>
-            )
-          })}
-        </ul>
-      ) : (
-        <div className={gridClass}>
-          {notes.map(n => {
-            const date = new Date(n.updated_at).toUTCString()
-            return (
-              <Link key={n.id} href={`/notes/${n.id}`} className="block h-full">
-                <Card className="h-full flex flex-col hover:bg-accent/30 transition">
-                  <CardContent className="p-4 flex-1">
-                    <div className="font-medium">{n.title || 'Untitled'}</div>
-                    <div className="text-xs text-muted-foreground">
-                      Updated {date} • {n.openTasks} open tasks
-                    </div>
-                  </CardContent>
-                </Card>
-              </Link>
-            )
-          })}
-        </div>
-      )}
+  return view === 'list' ? (
+    <ul className="divide-y">
+      {notes.map(n => {
+        const date = new Date(n.updated_at).toUTCString()
+        return (
+          <li key={n.id}>
+            <Link
+              href={`/notes/${n.id}`}
+              className="flex items-center justify-between py-2"
+            >
+              <span className="font-medium">{n.title || 'Untitled'}</span>
+              <span className="text-xs text-muted-foreground">
+                Updated {date} • {n.openTasks} open tasks
+              </span>
+            </Link>
+          </li>
+        )
+      })}
+    </ul>
+  ) : (
+    <div className={gridClass}>
+      {notes.map(n => {
+        const date = new Date(n.updated_at).toUTCString()
+        return (
+          <Link key={n.id} href={`/notes/${n.id}`} className="block h-full">
+            <Card className="h-full flex flex-col hover:bg-accent/30 transition">
+              <CardContent className="p-4 flex-1">
+                <div className="font-medium">{n.title || 'Untitled'}</div>
+                <div className="text-xs text-muted-foreground">
+                  Updated {date} • {n.openTasks} open tasks
+                </div>
+              </CardContent>
+            </Card>
+          </Link>
+        )
+      })}
     </div>
   )
 }

--- a/src/app/notes/__tests__/NotesClient.test.tsx
+++ b/src/app/notes/__tests__/NotesClient.test.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+(globalThis as unknown as { React: typeof React }).React = React;
+import { fireEvent, render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+const replace = vi.fn();
+const params = new URLSearchParams();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+  usePathname: () => "/notes",
+  useSearchParams: () => params,
+}));
+
+import { NotesClient } from "../page";
+
+const notes = [
+  { id: "1", title: "Alpha", updated_at: "2024-01-02T00:00:00Z", openTasks: 0 },
+  { id: "2", title: "Beta", updated_at: "2024-01-01T00:00:00Z", openTasks: 0 },
+];
+
+test("filter bar toggles and filters notes", () => {
+  render(<NotesClient notes={notes} />);
+
+  // Initially hidden
+  expect(screen.queryByPlaceholderText("Search title…")).toBeNull();
+
+  // Toggle filter bar
+  fireEvent.click(screen.getByLabelText("Toggle filters"));
+  const search = screen.getByPlaceholderText("Search title…");
+  expect(search).toBeTruthy();
+
+  // Search filter
+  fireEvent.change(search, { target: { value: "Alpha" } });
+  expect(screen.getByText("Alpha")).toBeTruthy();
+  expect(screen.queryByText("Beta")).toBeNull();
+
+  // Sort oldest
+  fireEvent.change(search, { target: { value: "" } });
+  const select = screen.getByLabelText("Sort notes") as HTMLSelectElement;
+  fireEvent.change(select, { target: { value: "oldest" } });
+  const links = screen.getAllByRole("link");
+  expect(links[0].textContent).toContain("Beta");
+});

--- a/src/app/notes/__tests__/NotesClient.test.tsx
+++ b/src/app/notes/__tests__/NotesClient.test.tsx
@@ -11,7 +11,7 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => params,
 }));
 
-import { NotesClient } from "../page";
+import { NotesClient } from "../NotesClient";
 
 const notes = [
   { id: "1", title: "Alpha", updated_at: "2024-01-02T00:00:00Z", openTasks: 0 },

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -5,13 +5,10 @@ import { redirect } from 'next/navigation'
 import { createNote } from '@/app/actions'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import { NotesList, Note } from './NotesList'
+import { Note } from './NotesList'
 import { countOpenTasks } from '@/lib/taskparse'
 import { NavButton } from '@/components/NavButton'
-import ViewSelector from '@/components/ViewSelector'
-import FilterBar, { NoteFilters } from '@/components/notes/FilterBar'
-import { Filter, LayoutPanelTop, LayoutGrid, List } from 'lucide-react'
-import { useState, useMemo } from 'react'
+import { NotesClient } from './NotesClient'
 
 export default async function NotesPage() {
   const supabase = await supabaseServer()
@@ -23,7 +20,7 @@ export default async function NotesPage() {
     .select('id,title,updated_at,body')
     .order('updated_at', { ascending: false })
 
-  const enriched = (notes ?? []).map(n => ({
+  const enriched: Note[] = (notes ?? []).map(n => ({
     id: n.id,
     title: n.title,
     updated_at: n.updated_at,
@@ -49,50 +46,6 @@ export default async function NotesPage() {
       </div>
 
       <NotesClient notes={enriched} />
-    </div>
-  )
-}
-
-export function NotesClient({ notes }: { notes: Note[] }) {
-  'use client'
-  const [showFilters, setShowFilters] = useState(false)
-  const [filters, setFilters] = useState<NoteFilters>({ sort: 'newest' })
-
-  const filtered = useMemo(() => {
-    let res = [...notes]
-    if (filters.search) {
-      const s = filters.search.toLowerCase()
-      res = res.filter(n => n.title?.toLowerCase().includes(s))
-    }
-    res.sort((a, b) => {
-      const diff = new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime()
-      return filters.sort === 'oldest' ? diff : -diff
-    })
-    return res
-  }, [notes, filters])
-
-  return (
-    <div className="space-y-3">
-      <div className="flex items-center gap-2">
-        <ViewSelector
-          defaultValue="card"
-          options={[
-            { value: 'card', label: 'Card', icon: LayoutPanelTop },
-            { value: 'grid', label: 'Grid', icon: LayoutGrid },
-            { value: 'list', label: 'List', icon: List },
-          ]}
-        />
-        <button
-          type="button"
-          aria-label="Toggle filters"
-          onClick={() => setShowFilters(s => !s)}
-          className="rounded-md border border-input p-2 hover:bg-accent/50"
-        >
-          <Filter className="size-4" />
-        </button>
-      </div>
-      {showFilters && <FilterBar onChange={setFilters} />}
-      <NotesList notes={filtered} />
     </div>
   )
 }

--- a/src/components/notes/FilterBar.tsx
+++ b/src/components/notes/FilterBar.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Input } from '@/components/ui/input'
+
+export interface NoteFilters {
+  search?: string
+  sort: 'newest' | 'oldest'
+}
+
+interface FilterBarProps {
+  onChange: (filters: NoteFilters) => void
+}
+
+export default function FilterBar({ onChange }: FilterBarProps) {
+  const [filters, setFilters] = useState<NoteFilters>({ sort: 'newest' })
+
+  useEffect(() => {
+    onChange(filters)
+  }, [filters, onChange])
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Input
+        placeholder="Search title…"
+        value={filters.search ?? ''}
+        onChange={e => setFilters(f => ({ ...f, search: e.target.value || undefined }))}
+        aria-label="Search title"
+        className="h-9 w-48"
+      />
+      <select
+        value={filters.sort}
+        onChange={e => setFilters(f => ({ ...f, sort: e.target.value as NoteFilters['sort'] }))}
+        className="h-9 rounded-md border border-input bg-transparent px-2"
+        aria-label="Sort notes"
+      >
+        <option value="newest">Modified (newest)</option>
+        <option value="oldest">Modified (oldest)</option>
+      </select>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add FilterBar for searching and sorting notes
- toggle FilterBar from notes page and apply client-side filters
- test note filtering and sort behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6bbbd3e548327b9878141f447bdbe