### PR TITLE
feat(tasks): add toggleable filter bar

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -6,11 +6,8 @@ import { NavButton } from '@/components/NavButton'
 import { extractTasksFromHtml, filterTasks, TaskFilters, TaskWithNote } from '@/lib/taskparse'
 import { toggleTaskFromNote, setTaskDueFromNote } from '@/app/actions'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
 import TaskRow from '@/components/tasks/TaskRow'
-import ViewSelector from '@/components/ViewSelector'
-import { LayoutPanelTop, List as ListIcon } from 'lucide-react'
+import TasksFilters from '@/components/tasks/TasksFilters'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function handleToggle(noteId: string, line: number, _done: boolean) {
@@ -44,6 +41,7 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
   }
 
   const tagOptions = Array.from(new Set(tasks.flatMap(t => t.tags))).sort()
+  const noteOptions = (notes ?? []).map(n => ({ id: n.id, title: n.title || 'Untitled' }))
 
   const params = await searchParams
 
@@ -82,67 +80,7 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
           <CardTitle>Task List</CardTitle>
         </CardHeader>
         <CardContent>
-          <form className="mb-4 flex flex-wrap gap-2">
-            <select
-              name="completion"
-              defaultValue={filters.completion ?? ''}
-              className="h-9 rounded-md border border-input bg-transparent px-2"
-            >
-              <option value="">All</option>
-              <option value="open">Open</option>
-              <option value="done">Done</option>
-            </select>
-            <select
-              name="note"
-              defaultValue={noteId ?? ''}
-              className="h-9 rounded-md border border-input bg-transparent px-2"
-            >
-              <option value="">All Notes</option>
-              {notes?.map(n => (
-                <option key={n.id} value={n.id}>
-                  {n.title || 'Untitled'}
-                </option>
-              ))}
-            </select>
-            <select
-              name="tag"
-              defaultValue={filters.tag ?? ''}
-              className="h-9 rounded-md border border-input bg-transparent px-2"
-            >
-              <option value="">All Tags</option>
-              {tagOptions.map(tag => (
-                <option key={tag} value={tag}>
-                  {tag}
-                </option>
-              ))}
-            </select>
-            <Input
-              type="date"
-              name="due"
-              placeholder="Due date"
-              title="Selecting a date narrows tasks whose metadata includes due:YYYY-MM-DD"
-              defaultValue={filters.due ?? ''}
-              className="w-36"
-            />
-            <select
-              name="sort"
-              defaultValue={filters.sort ?? ''}
-              className="h-9 rounded-md border border-input bg-transparent px-2"
-            >
-              <option value="">Sort</option>
-              <option value="due">Due</option>
-              <option value="text">Text</option>
-            </select>
-            <Button type="submit">Apply</Button>
-          </form>
-          <ViewSelector
-            defaultValue="list"
-            options={[
-              { value: 'list', label: 'List', icon: ListIcon },
-              { value: 'card', label: 'Card', icon: LayoutPanelTop },
-            ]}
-            className="mb-4"
-          />
+          <TasksFilters notes={noteOptions} tags={tagOptions} />
           {groups.length === 0 ? (
             <p className="text-muted-foreground">{emptyMessage}</p>
           ) : view === 'card' ? (

--- a/src/components/tasks/TasksFilters.tsx
+++ b/src/components/tasks/TasksFilters.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { useState } from 'react'
+import ViewSelector from '@/components/ViewSelector'
+import TasksFilterBar from './TasksFilterBar'
+import { Filter, LayoutPanelTop, List } from 'lucide-react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import type { TaskFilters } from '@/lib/taskparse'
+
+type NoteOption = { id: string; title: string }
+
+interface TasksFiltersProps {
+  notes: NoteOption[]
+  tags: string[]
+}
+
+interface FilterState extends TaskFilters {
+  note?: string
+}
+
+export default function TasksFilters({ notes, tags }: TasksFiltersProps) {
+  const [open, setOpen] = useState(false)
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  function handleApply(filters: FilterState) {
+    const params = new URLSearchParams(searchParams.toString())
+    Object.entries(filters).forEach(([key, value]) => {
+      if (value) params.set(key, value)
+      else params.delete(key)
+    })
+    router.push(`?${params.toString()}`)
+    setOpen(false)
+  }
+
+  return (
+    <div className="mb-4 space-y-4">
+      <div className="flex items-center gap-2">
+        <ViewSelector
+          defaultValue="list"
+          options={[
+            { value: 'list', label: 'List', icon: List },
+            { value: 'card', label: 'Card', icon: LayoutPanelTop },
+          ]}
+        />
+        <button
+          type="button"
+          aria-label="Toggle filters"
+          onClick={() => setOpen(o => !o)}
+          className="rounded-md border border-input p-2 hover:bg-accent/50"
+        >
+          <Filter className="size-4" />
+        </button>
+      </div>
+      {open && (
+        <TasksFilterBar
+          notes={notes}
+          tags={tags}
+          onChange={() => {}}
+          onApply={handleApply}
+        />
+      )}
+    </div>
+  )
+}
+


### PR DESCRIPTION
## Summary
- replace inline task filters with toggleable `TasksFilterBar`
- ensure filter selections update URL search params via router
- add unit test for filter toggle

## Testing
- `npm test`
- `npm run lint`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run build`
- `npm run typecheck` *(fails: Missing script: "typecheck")*

------
https://chatgpt.com/codex/tasks/task_e_68b6db3341bc8327ab4a2abe272a24e2