### PR TITLE
feat(tasks): add view selector and card layout

### DIFF
--- a/src/app/tasks/__tests__/TasksPage.test.tsx
+++ b/src/app/tasks/__tests__/TasksPage.test.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+(globalThis as unknown as { React: typeof React }).React = React;
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+const params = new URLSearchParams();
+const push = vi.fn();
+const replace = vi.fn();
+const prefetch = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, replace, prefetch }),
+  useSearchParams: () => params,
+  usePathname: () => "/tasks",
+  redirect: vi.fn(),
+}));
+
+vi.mock("@/app/actions", () => ({
+  toggleTaskFromNote: vi.fn(),
+  setTaskDueFromNote: vi.fn(),
+}));
+
+const notes = [
+  {
+    id: "n1",
+    title: "Note A",
+    updated_at: "2024-01-01T00:00:00Z",
+    body: '<ul><li data-type="taskItem" data-checked="false"><div>Task 1</div></li></ul>',
+  },
+  {
+    id: "n2",
+    title: "Note B",
+    updated_at: "2024-01-02T00:00:00Z",
+    body: '<ul><li data-type="taskItem" data-checked="false"><div>Task 2</div></li></ul>',
+  },
+];
+
+vi.mock("@/lib/supabase-server", () => ({
+  supabaseServer: async () => ({
+    auth: { getUser: async () => ({ data: { user: {} } }) },
+    from: () => ({
+      select: () => ({
+        order: () => Promise.resolve({ data: notes }),
+      }),
+    }),
+  }),
+}));
+
+import TasksPage from "../page";
+
+test("renders list view by default", async () => {
+  params.set("view", "list");
+  const { container } = render(
+    await TasksPage({ searchParams: Promise.resolve({ view: "list" }) })
+  );
+  expect(container.querySelectorAll('[data-slot="card"]').length).toBe(1);
+  expect(screen.getByText("Note A")).toBeTruthy();
+  expect(screen.getByText("Note B")).toBeTruthy();
+});
+
+test("renders card view when view=card", async () => {
+  params.set("view", "card");
+  const { container } = render(
+    await TasksPage({ searchParams: Promise.resolve({ view: "card" }) })
+  );
+  // outer card + two note group cards
+  expect(container.querySelectorAll('[data-slot="card"]').length).toBe(3);
+});

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -8,6 +8,8 @@ import { toggleTaskFromNote, setTaskDueFromNote } from '@/app/actions'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import TaskRow from '@/components/tasks/TaskRow'
 import TasksFilters from '@/components/tasks/TasksFilters'
+import ViewSelector from '@/components/ViewSelector'
+import { List, LayoutPanelTop } from 'lucide-react'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function handleToggle(noteId: string, line: number, _done: boolean) {
@@ -80,7 +82,15 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
           <CardTitle>Task List</CardTitle>
         </CardHeader>
         <CardContent>
-          <TasksFilters notes={noteOptions} tags={tagOptions} />
+          <TasksFilters notes={noteOptions} tags={tagOptions}>
+            <ViewSelector
+              defaultValue="list"
+              options={[
+                { value: 'list', label: 'List', icon: List },
+                { value: 'card', label: 'Card', icon: LayoutPanelTop },
+              ]}
+            />
+          </TasksFilters>
           {groups.length === 0 ? (
             <p className="text-muted-foreground">{emptyMessage}</p>
           ) : view === 'card' ? (

--- a/src/components/tasks/TasksFilters.tsx
+++ b/src/components/tasks/TasksFilters.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-import { useState } from 'react'
-import ViewSelector from '@/components/ViewSelector'
+import { useState, type ReactNode } from 'react'
 import TasksFilterBar from './TasksFilterBar'
-import { Filter, LayoutPanelTop, List } from 'lucide-react'
+import { Filter } from 'lucide-react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import type { TaskFilters } from '@/lib/taskparse'
 
@@ -12,13 +11,14 @@ type NoteOption = { id: string; title: string }
 interface TasksFiltersProps {
   notes: NoteOption[]
   tags: string[]
+  children?: ReactNode
 }
 
 interface FilterState extends TaskFilters {
   note?: string
 }
 
-export default function TasksFilters({ notes, tags }: TasksFiltersProps) {
+export default function TasksFilters({ notes, tags, children }: TasksFiltersProps) {
   const [open, setOpen] = useState(false)
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -36,13 +36,7 @@ export default function TasksFilters({ notes, tags }: TasksFiltersProps) {
   return (
     <div className="mb-4 space-y-4">
       <div className="flex items-center gap-2">
-        <ViewSelector
-          defaultValue="list"
-          options={[
-            { value: 'list', label: 'List', icon: List },
-            { value: 'card', label: 'Card', icon: LayoutPanelTop },
-          ]}
-        />
+        {children}
         <button
           type="button"
           aria-label="Toggle filters"


### PR DESCRIPTION
## Summary
- add view selector to tasks page and share filtering for list/card views
- render tasks in responsive card grid grouped by note
- test task page list vs card view rendering

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Missing script: "typecheck")*
- `npm run build` *(fails: Missing env var NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68b6dde8b08883278e2ebf056bc448eb