### PR TITLE
feat: link due date picker

### DIFF
--- a/src/components/tasks/DateFilterTrigger.tsx
+++ b/src/components/tasks/DateFilterTrigger.tsx
@@ -1,6 +1,13 @@
 'use client'
 
-import { useEffect, useState, useCallback, useRef } from 'react'
+import {
+  useEffect,
+  useState,
+  useCallback,
+  useRef,
+  type ReactNode,
+  type ComponentProps,
+} from 'react'
 import { Button } from '@/components/ui/button'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { track } from '@/lib/analytics'
@@ -9,9 +16,19 @@ export interface DateFilterTriggerProps {
   value?: string
   onChange: (value: string) => void
   onClear?: () => void
+  className?: string
+  variant?: ComponentProps<typeof Button>['variant']
+  children?: ReactNode
 }
 
-export default function DateFilterTrigger({ value, onChange, onClear }: DateFilterTriggerProps) {
+export default function DateFilterTrigger({
+  value,
+  onChange,
+  onClear,
+  className,
+  variant = 'outline',
+  children,
+}: DateFilterTriggerProps) {
   const [open, setOpen] = useState(false)
   const [month, setMonth] = useState(() => {
     const d = value ? new Date(value) : new Date()
@@ -122,7 +139,8 @@ export default function DateFilterTrigger({ value, onChange, onClear }: DateFilt
     <div className="relative inline-block">
       <Button
         type="button"
-        variant="outline"
+        variant={variant}
+        className={className}
         aria-haspopup="dialog"
         aria-expanded={open}
         onClick={() =>
@@ -133,7 +151,7 @@ export default function DateFilterTrigger({ value, onChange, onClear }: DateFilt
           })
         }
       >
-        {value || 'Select date'}
+        {(children ?? value) || 'Select date'}
       </Button>
       {open && (
         <div

--- a/src/components/tasks/TaskRow.tsx
+++ b/src/components/tasks/TaskRow.tsx
@@ -17,6 +17,10 @@ interface TaskRowProps {
 }
 
 export default function TaskRow({ task, onToggle, onDueChange }: TaskRowProps) {
+  const label = task.due
+    ? new Date(task.due).toLocaleDateString()
+    : 'Set due date'
+
   return (
     <li className="flex items-center gap-2">
       <Checkbox
@@ -31,7 +35,11 @@ export default function TaskRow({ task, onToggle, onDueChange }: TaskRowProps) {
         value={task.due}
         onChange={onDueChange}
         onClear={() => onDueChange('')}
-      />
+        variant="link"
+        className="h-auto p-0 text-blue-600 hover:underline dark:text-blue-500"
+      >
+        {label}
+      </DateFilterTrigger>
     </li>
   )
 }

--- a/src/components/tasks/__tests__/TaskRow.test.tsx
+++ b/src/components/tasks/__tests__/TaskRow.test.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+(globalThis as unknown as { React: typeof React }).React = React;
+import { render, fireEvent, screen } from "@testing-library/react";
+import { vi } from "vitest";
+import TaskRow from "../TaskRow";
+
+function Wrapper() {
+  const [task, setTask] = React.useState({ title: "Test", done: false });
+  return (
+    <TaskRow
+      task={task}
+      onToggle={() => {}}
+      onDueChange={due => setTask(t => ({ ...t, due }))}
+    />
+  );
+}
+
+test("link label updates when date is set and cleared", () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2024-06-15"));
+  render(<Wrapper />);
+
+  fireEvent.click(screen.getByRole("button", { name: /set due date/i }));
+  fireEvent.click(screen.getByRole("button", { name: /today/i }));
+  const expected = new Date("2024-06-15").toLocaleDateString();
+  expect(screen.getByRole("button", { name: expected })).toBeTruthy();
+
+  fireEvent.click(screen.getByRole("button", { name: expected }));
+  fireEvent.click(screen.getByRole("button", { name: /clear/i }));
+  expect(screen.getByRole("button", { name: /set due date/i })).toBeTruthy();
+  vi.useRealTimers();
+});


### PR DESCRIPTION
## Summary
- render due dates in task rows as inline blue link
- add DateFilterTrigger flexibility for custom triggers
- test TaskRow due date label updating

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run typecheck` *(fails: Missing script "typecheck"*)

------
https://chatgpt.com/codex/tasks/task_e_68b6e02cc51483278c841b96f4b6bc9a