### PR TITLE
Refactor TaskRow to call server actions directly

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -4,25 +4,11 @@ import { supabaseServer } from '@/lib/supabase-server'
 import { redirect } from 'next/navigation'
 import { NavButton } from '@/components/NavButton'
 import { extractTasksFromHtml, filterTasks, TaskFilters, TaskWithNote } from '@/lib/taskparse'
-import { toggleTaskFromNote, setTaskDueFromNote } from '@/app/actions'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import TaskRow from '@/components/tasks/TaskRow'
 import TasksFilters from '@/components/tasks/TasksFilters'
 import ViewSelector from '@/components/ViewSelector'
 import { List, LayoutPanelTop } from 'lucide-react'
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-async function handleToggle(noteId: string, line: number, _done: boolean) {
-  'use server'
-  await toggleTaskFromNote(noteId, line)
-}
-
-async function handleDueChange(noteId: string, line: number, value: string) {
-  'use server'
-  const fd = new FormData()
-  fd.append('due', value)
-  await setTaskDueFromNote(noteId, line, fd)
-}
 
 export default async function TasksPage({ searchParams }: { searchParams: Promise<Record<string, string | string[] | undefined>> }) {
   const supabase = await supabaseServer()
@@ -114,8 +100,8 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
                         <TaskRow
                           key={t.line}
                           task={{ title: t.text, done: t.checked, due: t.due }}
-                          onToggle={handleToggle.bind(null, group.id, t.line)}
-                          onDueChange={handleDueChange.bind(null, group.id, t.line)}
+                          noteId={group.id}
+                          line={t.line}
                         />
                       ))}
                     </ul>
@@ -139,8 +125,8 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
                       <TaskRow
                         key={t.line}
                         task={{ title: t.text, done: t.checked, due: t.due }}
-                        onToggle={handleToggle.bind(null, group.id, t.line)}
-                        onDueChange={handleDueChange.bind(null, group.id, t.line)}
+                        noteId={group.id}
+                        line={t.line}
                       />
                     ))}
                   </ul>

--- a/src/components/tasks/__tests__/TaskRow.test.tsx
+++ b/src/components/tasks/__tests__/TaskRow.test.tsx
@@ -1,32 +1,34 @@
 import React from "react";
 (globalThis as unknown as { React: typeof React }).React = React;
-import { render, fireEvent, screen } from "@testing-library/react";
+import { render, fireEvent, screen, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 import TaskRow from "../TaskRow";
 
-function Wrapper() {
-  const [task, setTask] = React.useState({ title: "Test", done: false });
-  return (
-    <TaskRow
-      task={task}
-      onToggle={() => {}}
-      onDueChange={due => setTask(t => ({ ...t, due }))}
-    />
-  );
-}
+vi.mock("@/app/actions", () => ({
+  toggleTaskFromNote: vi.fn(),
+  setTaskDueFromNote: vi.fn(),
+}));
 
-test("link label updates when date is set and cleared", () => {
+test("calls toggleTaskFromNote when checkbox toggled", async () => {
+  const { toggleTaskFromNote } = await import("@/app/actions");
+  render(<TaskRow task={{ title: "Test", done: false }} noteId="n1" line={0} />);
+  fireEvent.click(screen.getByRole("checkbox"));
+  await waitFor(() => {
+    expect(toggleTaskFromNote).toHaveBeenCalledWith("n1", 0);
+  });
+});
+
+test("calls setTaskDueFromNote when date is selected", async () => {
   vi.useFakeTimers();
   vi.setSystemTime(new Date("2024-06-15"));
-  render(<Wrapper />);
-
+  const { setTaskDueFromNote } = await import("@/app/actions");
+  render(<TaskRow task={{ title: "Test", done: false }} noteId="n1" line={0} />);
   fireEvent.click(screen.getByRole("button", { name: /set due date/i }));
   fireEvent.click(screen.getByRole("button", { name: /today/i }));
-  const expected = new Date("2024-06-15").toLocaleDateString();
-  expect(screen.getByRole("button", { name: expected })).toBeTruthy();
-
-  fireEvent.click(screen.getByRole("button", { name: expected }));
-  fireEvent.click(screen.getByRole("button", { name: /clear/i }));
-  expect(screen.getByRole("button", { name: /set due date/i })).toBeTruthy();
+  await vi.runAllTimersAsync();
+  expect(setTaskDueFromNote).toHaveBeenCalled();
+  const fd = (setTaskDueFromNote as unknown as { mock: { calls: unknown[][] } }).mock
+    .calls[0][2] as FormData;
+  expect(fd.get("due")).toBe("2024-06-15");
   vi.useRealTimers();
 });


### PR DESCRIPTION
## Summary
- Pass `noteId` and task `line` to `TaskRow` from tasks page
- Invoke `toggleTaskFromNote` and `setTaskDueFromNote` directly in `TaskRow`
- Update TaskRow tests to assert server action calls

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Missing environment variable: NEXT_PUBLIC_SUPABASE_URL)*
- `npm run typecheck` *(fails: Missing script: "typecheck")*


------
https://chatgpt.com/codex/tasks/task_e_68b6e51e50c083279919eca7e3b2b6c1