### PR TITLE
refactor: use icon keys in view selector

### DIFF
--- a/src/app/notes/NotesClient.tsx
+++ b/src/app/notes/NotesClient.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo } from 'react'
 import ViewSelector from '@/components/ViewSelector'
 import FilterBar, { NoteFilters } from '@/components/notes/FilterBar'
-import { Filter, LayoutPanelTop, LayoutGrid, List } from 'lucide-react'
+import { Filter } from 'lucide-react'
 import { NotesList, type Note } from './NotesList'
 
 export function NotesClient({ notes }: { notes: Note[] }) {
@@ -29,9 +29,9 @@ export function NotesClient({ notes }: { notes: Note[] }) {
         <ViewSelector
           defaultValue="card"
           options={[
-            { value: 'card', label: 'Card', icon: LayoutPanelTop },
-            { value: 'grid', label: 'Grid', icon: LayoutGrid },
-            { value: 'list', label: 'List', icon: List },
+            { value: 'card', label: 'Card', icon: 'card' },
+            { value: 'grid', label: 'Grid', icon: 'grid' },
+            { value: 'list', label: 'List', icon: 'list' },
           ]}
         />
         <button

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -8,7 +8,6 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import TaskRow from '@/components/tasks/TaskRow'
 import TasksFilters from '@/components/tasks/TasksFilters'
 import ViewSelector from '@/components/ViewSelector'
-import { List, LayoutPanelTop } from 'lucide-react'
 
 export default async function TasksPage({ searchParams }: { searchParams: Promise<Record<string, string | string[] | undefined>> }) {
   const supabase = await supabaseServer()
@@ -72,8 +71,8 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
             <ViewSelector
               defaultValue="list"
               options={[
-                { value: 'list', label: 'List', icon: List },
-                { value: 'card', label: 'Card', icon: LayoutPanelTop },
+                { value: 'list', label: 'List', icon: 'list' },
+                { value: 'card', label: 'Card', icon: 'card' },
               ]}
             />
           </TasksFilters>

--- a/src/components/ViewSelector.tsx
+++ b/src/components/ViewSelector.tsx
@@ -1,13 +1,24 @@
 'use client'
 
-import { LucideIcon } from 'lucide-react'
+import {
+  type LucideIcon,
+  LayoutPanelTop,
+  LayoutGrid,
+  List,
+} from 'lucide-react'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { cn } from '@/lib/utils'
+
+const icons = {
+  list: List,
+  card: LayoutPanelTop,
+  grid: LayoutGrid,
+} satisfies Record<string, LucideIcon>
 
 export type ViewOption = {
   value: string
   label: string
-  icon: LucideIcon
+  icon: keyof typeof icons
 }
 
 interface ViewSelectorProps {
@@ -38,7 +49,7 @@ export function ViewSelector({ options, paramKey = 'view', defaultValue, classNa
       )}
     >
       {options.map(opt => {
-        const Icon = opt.icon
+        const Icon = icons[opt.icon]
         const active = current === opt.value
         return (
           <button

--- a/src/components/__tests__/ViewSelector.test.tsx
+++ b/src/components/__tests__/ViewSelector.test.tsx
@@ -11,7 +11,6 @@ vi.mock('next/navigation', () => ({
 }))
 
 import ViewSelector from '../ViewSelector'
-import { LayoutPanelTop, List } from 'lucide-react'
 
 describe('ViewSelector', () => {
   beforeEach(() => replace.mockClear())
@@ -21,8 +20,8 @@ describe('ViewSelector', () => {
       <ViewSelector
         defaultValue="card"
         options={[
-          { value: 'card', label: 'Card', icon: LayoutPanelTop },
-          { value: 'list', label: 'List', icon: List },
+          { value: 'card', label: 'Card', icon: 'card' },
+          { value: 'list', label: 'List', icon: 'list' },
         ]}
       />
     )


### PR DESCRIPTION
## Summary
- refactor ViewSelector to accept string icon keys and map them to Lucide icons
- update tasks and notes views to pass icon key strings
- adjust ViewSelector tests for icon key API

## Testing
- `npm run lint`
- `npm test`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=foo npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6ea46c6908327ab1bb3b2f89e3fa9