### PR TITLE
Add blank note creation with redirect

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -14,10 +14,16 @@ export async function requireUser() {
   return { supabase, user };
 }
 
-export async function createNote(title: string) {
+export async function createNote(title?: string) {
   const { supabase, user } = await requireUser();
-  await supabase.from("notes").insert({ title, user_id: user.id, body: "" });
+  const { data, error } = await supabase
+    .from("notes")
+    .insert({ title: title ?? "Untitled", user_id: user.id, body: "" })
+    .select("id")
+    .single();
+  if (error) throw error;
   revalidatePath("/notes");
+  return data?.id as string;
 }
 
 export async function updateNoteTitle(id: string, title: string) {

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -4,7 +4,6 @@ import { supabaseServer } from '@/lib/supabase-server'
 import { redirect } from 'next/navigation'
 import { createNote } from '@/app/actions'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
 import { Note } from './NotesList'
 import { countOpenTasks } from '@/lib/taskparse'
 import { NavButton } from '@/components/NavButton'
@@ -27,18 +26,17 @@ export default async function NotesPage() {
     openTasks: countOpenTasks(n.body || '')
   }))
 
-  async function newNote(formData: FormData) {
+  async function createBlankNote() {
     'use server'
-    const title = (formData.get('title') as string) || 'Untitled'
-    await createNote(title)
+    const id = await createNote()
+    redirect(`/notes/${id}`)
   }
 
   return (
     <div className="space-y-6">
       <div className="flex gap-2">
-        <form action={newNote} className="flex gap-2 flex-1">
-          <Input name="title" placeholder="New note title…" />
-          <Button type="submit">Add</Button>
+        <form action={createBlankNote}>
+          <Button type="submit">New</Button>
         </form>
         <NavButton href="/tasks" variant="outline">
           View Tasks

--- a/src/components/NoteTitleInput.tsx
+++ b/src/components/NoteTitleInput.tsx
@@ -80,6 +80,7 @@ export default function NoteTitleInput({
         value={title}
         onChange={handleChange}
         onBlur={handleBlur}
+        autoFocus
         variant="title"
         className="text-3xl md:text-3xl font-bold h-auto py-0 border-0 px-0 focus-visible:ring-0"
       />


### PR DESCRIPTION
## Summary
- Replace titled note form with a "New" button that creates a blank note and redirects to it
- Return note ID from createNote for immediate redirect
- Autofocus note title input when editing

## Testing
- `npm run lint`
- `npm test`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b75d951f4483279b63ffd94b9a1f54