### PR TITLE
refactor: consolidate note saving

### DIFF
--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -332,6 +332,7 @@ export default function InlineEditor({
 
   const runSave = React.useCallback(
     (html: string, opts?: { sync?: boolean }) => {
+      const docHtml = `<html><body>${html}</body></html>`;
       if (retryTimeout.current) {
         clearTimeout(retryTimeout.current);
         retryTimeout.current = null;
@@ -341,7 +342,7 @@ export default function InlineEditor({
         setStatus("saving");
         try {
           const data = new Blob(
-            [JSON.stringify({ id: noteId, html })],
+            [JSON.stringify({ id: noteId, html: docHtml })],
             { type: "application/json" },
           );
           navigator.sendBeacon("/api/save-note-inline", data);
@@ -350,7 +351,7 @@ export default function InlineEditor({
         return Promise.resolve({ openTasks: 0, updatedAt: null });
       }
       return saveWithRetry(
-        () => saveNoteInline(noteId, html, { revalidate: false }),
+        () => saveNoteInline(noteId, docHtml, { revalidate: false }),
         setStatus,
         attempts,
         retryTimeout,


### PR DESCRIPTION
## Summary
- remove unused `saveNote` action in favor of single `saveNoteInline`
- parse first `<h1>` from provided HTML and persist `{title, body, open_tasks}`
- send full document HTML from editor when autosaving

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Missing script)*
- `npm run build` *(fails: Missing environment variable: NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d0b04f288327bef06aaf07438eb6