### PR TITLE
Delete untouched notes on blur

### DIFF
--- a/src/app/notes/[id]/__tests__/NoteClient.test.tsx
+++ b/src/app/notes/[id]/__tests__/NoteClient.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+(globalThis as unknown as { React: typeof React }).React = React;
+import { fireEvent, render } from "@testing-library/react";
+import { vi } from "vitest";
+import NoteClient from "../NoteClient";
+
+let changeHandler: (html: string) => void = () => {};
+
+vi.mock("@/components/editor/InlineEditor", () => ({
+  __esModule: true,
+  default: (props: { onBlur?: () => void; onChange?: (h: string) => void }) => {
+    changeHandler = props.onChange ?? (() => {});
+    return <div data-testid="editor" tabIndex={0} onBlur={props.onBlur} />;
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ prefetch: vi.fn(), push: vi.fn() }),
+}));
+
+describe("NoteClient", () => {
+  beforeEach(() => {
+    changeHandler = () => {};
+  });
+
+  const baseProps = {
+    noteId: "1",
+    html: "<h1></h1>",
+    created: "",
+    modified: "",
+    openTasks: 0,
+  };
+
+  it("deletes empty note on blur", () => {
+    const onDelete = vi.fn();
+    const { getByTestId } = render(
+      <NoteClient {...baseProps} onDelete={onDelete} />,
+    );
+    const editor = getByTestId("editor");
+    editor.focus();
+    fireEvent.blur(editor);
+    expect(onDelete).toHaveBeenCalled();
+  });
+
+  it("keeps note when user typed", () => {
+    const onDelete = vi.fn();
+    const { getByTestId } = render(
+      <NoteClient {...baseProps} onDelete={onDelete} />,
+    );
+    changeHandler("<h1>Title</h1><p>content</p>");
+    const editor = getByTestId("editor");
+    editor.focus();
+    fireEvent.blur(editor);
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -19,12 +19,17 @@ export default async function NotesPage() {
     .select('id,title,updated_at,body')
     .order('updated_at', { ascending: false })
 
-  const enriched: Note[] = (notes ?? []).map(n => ({
-    id: n.id,
-    title: n.title,
-    updated_at: n.updated_at,
-    openTasks: countOpenTasks(n.body || '')
-  }))
+  const enriched: Note[] = (notes ?? [])
+    .filter(n => {
+      const body = (n.body ?? '').trim()
+      return body !== '' && body !== '<h1></h1>'
+    })
+    .map(n => ({
+      id: n.id,
+      title: n.title,
+      updated_at: n.updated_at,
+      openTasks: countOpenTasks(n.body || '')
+    }))
 
   async function createBlankNote() {
     'use server'

--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -27,6 +27,7 @@ export interface InlineEditorProps {
   html: string;
   onChange?: (html: string) => void;
   onSaved?: (res: SaveNoteInlineResult) => void;
+  onBlur?: () => void;
 }
 
 export const AUTOSAVE_THROTTLE_MS = 3000;
@@ -258,6 +259,7 @@ export default function InlineEditor({
   html,
   onChange,
   onSaved,
+  onBlur,
 }: InlineEditorProps) {
   const editor = useEditor({
     extensions: createInlineEditorExtensions(),
@@ -385,6 +387,7 @@ export default function InlineEditor({
     const blurHandler = () => {
       const current = editor.getHTML();
       onChange?.(current);
+      onBlur?.();
       if (saveTimeout.current) clearTimeout(saveTimeout.current);
       if (retryTimeout.current) {
         clearTimeout(retryTimeout.current);
@@ -401,7 +404,7 @@ export default function InlineEditor({
       if (saveTimeout.current) clearTimeout(saveTimeout.current);
       if (retryTimeout.current) clearTimeout(retryTimeout.current);
     };
-  }, [editor, noteId, onChange, runSave]);
+  }, [editor, noteId, onChange, onBlur, runSave]);
 
   React.useEffect(() => {
     if (!editor) return;


### PR DESCRIPTION
## Summary
- track editor content to detect whether user has typed and delete note if left empty on blur or before unload
- allow InlineEditor to report blur events
- hide empty notes from notes list
- test automatic deletion of empty notes

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: Missing environment variable NEXT_PUBLIC_SUPABASE_URL)*
- `npm run typecheck` *(fails: Missing script "typecheck")*


------
https://chatgpt.com/codex/tasks/task_e_68b7d42c08d883278941c9f7334b1f1d