### PR TITLE
feat: add note title heading migration

### DIFF
--- a/scripts/migrate-notes.ts
+++ b/scripts/migrate-notes.ts
@@ -1,0 +1,42 @@
+import { createClient } from '@supabase/supabase-js';
+
+const { NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY } = process.env;
+
+if (!NEXT_PUBLIC_SUPABASE_URL || !(SUPABASE_SERVICE_ROLE_KEY || NEXT_PUBLIC_SUPABASE_ANON_KEY)) {
+  console.error('Missing Supabase configuration');
+  process.exit(1);
+}
+
+const supabase = createClient(
+  NEXT_PUBLIC_SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY || NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+);
+
+async function migrate() {
+  const { data: notes, error } = await supabase.from('notes').select('id, title, body');
+  if (error) {
+    console.error('Failed to fetch notes', error);
+    return;
+  }
+
+  for (const note of notes ?? []) {
+    const body = (note.body as string | null)?.trim();
+    const title = note.title as string | null;
+    if (!body || !title) continue;
+    if (!/^<h[1-6]/i.test(body)) {
+      const updatedBody = `<h1>${title}</h1>${body}`;
+      await supabase.from('notes').update({ body: updatedBody }).eq('id', note.id);
+      console.log(`Updated note ${note.id}`);
+    }
+  }
+}
+
+migrate()
+  .then(() => {
+    console.log('Migration complete');
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/supabase/migrations/20250326000000_prepend_title_to_body.sql
+++ b/supabase/migrations/20250326000000_prepend_title_to_body.sql
@@ -1,0 +1,6 @@
+-- Prepend title as <h1> heading to body when missing
+UPDATE notes
+SET body = '<h1>' || title || '</h1>' || body
+WHERE NOT (body ~ '^<h[1-6]');
+
+-- Title column retained for indexing


### PR DESCRIPTION
## Summary
- prepend note titles to bodies when missing via migration
- add script to migrate existing deployments

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck` *(fails: Missing script "typecheck")*
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon NEXT_PUBLIC_POSTHOG_KEY=key NEXT_PUBLIC_POSTHOG_HOST=http://localhost NEXT_PUBLIC_SITE_URL=http://localhost npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7d885997c8327bcfa3582d3c5e15d