### PR TITLE
Derive note titles from body

### DIFF
--- a/src/app/notes/NotesClient.tsx
+++ b/src/app/notes/NotesClient.tsx
@@ -14,7 +14,7 @@ export function NotesClient({ notes }: { notes: Note[] }) {
     let res = [...notes]
     if (filters.search) {
       const s = filters.search.toLowerCase()
-      res = res.filter(n => n.title?.toLowerCase().includes(s))
+      res = res.filter(n => n.title.toLowerCase().includes(s))
     }
     res.sort((a, b) => {
       const diff = new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime()

--- a/src/app/notes/NotesList.tsx
+++ b/src/app/notes/NotesList.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from 'next/navigation'
 import { Card, CardContent } from '@/components/ui/card'
 export type Note = {
   id: string
-  title: string | null
+  title: string
   updated_at: string
   openTasks: number
 }

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -8,28 +8,29 @@ import { Note } from './NotesList'
 import { countOpenTasks } from '@/lib/taskparse'
 import { NavButton } from '@/components/NavButton'
 import { NotesClient } from './NotesClient'
+import { extractTitleFromHtml } from '@/lib/note'
 
 export default async function NotesPage() {
   const supabase = await supabaseServer()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) redirect('/login')
 
-  const { data: notes } = await supabase
-    .from('notes')
-    .select('id,title,updated_at,body')
-    .order('updated_at', { ascending: false })
+    const { data: notes } = await supabase
+      .from('notes')
+      .select('id,updated_at,body')
+      .order('updated_at', { ascending: false })
 
   const enriched: Note[] = (notes ?? [])
     .filter(n => {
       const body = (n.body ?? '').trim()
       return body !== '' && body !== '<h1></h1>'
     })
-    .map(n => ({
-      id: n.id,
-      title: n.title,
-      updated_at: n.updated_at,
-      openTasks: countOpenTasks(n.body || '')
-    }))
+      .map(n => ({
+        id: n.id,
+        title: extractTitleFromHtml(n.body),
+        updated_at: n.updated_at,
+        openTasks: countOpenTasks(n.body || '')
+      }))
 
   async function createBlankNote() {
     'use server'

--- a/src/app/tasks/__tests__/TasksPage.test.tsx
+++ b/src/app/tasks/__tests__/TasksPage.test.tsx
@@ -19,20 +19,18 @@ vi.mock("@/app/actions", () => ({
   setTaskDueFromNote: vi.fn(),
 }));
 
-const notes = [
-  {
-    id: "n1",
-    title: "Note A",
-    updated_at: "2024-01-01T00:00:00Z",
-    body: '<ul><li data-type="taskItem" data-checked="false"><div>Task 1</div></li></ul>',
-  },
-  {
-    id: "n2",
-    title: "Note B",
-    updated_at: "2024-01-02T00:00:00Z",
-    body: '<ul><li data-type="taskItem" data-checked="false"><div>Task 2</div></li></ul>',
-  },
-];
+  const notes = [
+    {
+      id: "n1",
+      updated_at: "2024-01-01T00:00:00Z",
+      body: '<h1>Note A</h1><ul><li data-type="taskItem" data-checked="false"><div>Task 1</div></li></ul>',
+    },
+    {
+      id: "n2",
+      updated_at: "2024-01-02T00:00:00Z",
+      body: '<h1>Note B</h1><ul><li data-type="taskItem" data-checked="false"><div>Task 2</div></li></ul>',
+    },
+  ];
 
 vi.mock("@/lib/supabase-server", () => ({
   supabaseServer: async () => ({

--- a/src/lib/note.ts
+++ b/src/lib/note.ts
@@ -1,0 +1,8 @@
+import { JSDOM } from 'jsdom'
+
+export function extractTitleFromHtml(html: string | null | undefined): string {
+  if (!html) return ''
+  const dom = new JSDOM(html)
+  const title = dom.window.document.querySelector('h1')?.textContent?.trim() ?? ''
+  return title
+}


### PR DESCRIPTION
## Summary
- Extract note titles from HTML with new `extractTitleFromHtml` utility and drop title column from Supabase queries
- Compute note titles server-side in notes and tasks pages, keeping clients and search functionality unchanged
- Update tests to reflect title derivation from note body

## Testing
- `npm test`
- `npm run lint`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7df999e108327a82faa11ee0546bb