### PR TITLE
test: cover note title placeholder and autosave

### DIFF
--- a/src/components/editor/__tests__/autosaveTitleBody.test.tsx
+++ b/src/components/editor/__tests__/autosaveTitleBody.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import "./setup";
+
+vi.mock("@/app/actions", () => ({
+  saveNoteInline: vi.fn(() =>
+    Promise.resolve({ openTasks: 0, updatedAt: "2024-01-02T00:00:00.000Z" })
+  ),
+}));
+
+vi.mock("../FloatingToolbar", () => ({
+  default: () => <div />,
+}));
+
+vi.mock("@/lib/supabase-client", () => ({
+  supabaseClient: {
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null } }) },
+  },
+}));
+
+vi.mock("tippy.js", () => {
+  const tippy = () => ({ destroy: vi.fn() });
+  (tippy as unknown as { default: typeof tippy }).default = tippy;
+  return tippy;
+});
+
+vi.mock("@tiptap/extension-drag-handle", async () => {
+  const actual = await vi.importActual<typeof import("@tiptap/core")>("@tiptap/core");
+  return { default: actual.Extension.create({ name: "dragHandle" }) };
+});
+
+import InlineEditor from "../InlineEditor";
+import { saveNoteInline } from "@/app/actions";
+
+describe("InlineEditor autosave", () => {
+  it("saves title and body together", async () => {
+    const { container } = render(
+      <InlineEditor noteId="note" html="<h1>Title</h1><p>Body</p>" />,
+    );
+    const editorEl = container.querySelector(".ProseMirror") as HTMLElement;
+    fireEvent.focus(editorEl);
+    fireEvent.blur(editorEl);
+    await waitFor(() => expect(saveNoteInline).toHaveBeenCalled());
+    expect(saveNoteInline.mock.calls[0][1]).toContain(
+      "<h1>Title</h1><p>Body</p>",
+    );
+  });
+});

--- a/src/components/editor/__tests__/titlePlaceholder.test.ts
+++ b/src/components/editor/__tests__/titlePlaceholder.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { Editor } from "@tiptap/core";
+import { createInlineEditorExtensions } from "../InlineEditor";
+import "./setup";
+
+describe("title placeholder", () => {
+  it("shows placeholder until typing and removes on input", () => {
+    const extensions = createInlineEditorExtensions().filter(
+      e => e.name !== "dragHandle",
+    );
+    const editor = new Editor({ extensions });
+    editor.commands.setContent("<h1></h1>", false, { preserveWhitespace: true });
+    const heading = editor.view.dom.querySelector("h1");
+    expect(heading?.getAttribute("data-placeholder")).toBe("Untitled Note");
+    editor.commands.insertContent("Title");
+    expect(heading?.getAttribute("data-placeholder")).toBeNull();
+    editor.commands.keyboardShortcut("Enter");
+    const json = editor.getJSON();
+    expect(json.content?.[0].type).toBe("heading");
+    expect(json.content?.[1].type).toBe("paragraph");
+    editor.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- add regression test for note title placeholder and heading enter behavior
- ensure autosave persists both title and body

## Testing
- `npm run build` *(fails: Missing environment variable: NEXT_PUBLIC_SUPABASE_URL)*
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7e34c7e54832785f1250b85b2192b