### PR TITLE
Store notes without document wrapper

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -33,11 +33,13 @@ export async function saveNoteInline(
   opts?: { revalidate?: boolean },
 ): Promise<SaveNoteInlineResult> {
   const { supabase, user } = await requireUser();
-  const title = extractTitleFromHtml(html);
-  const openTasks = countOpenTasks(html);
+  const dom = new JSDOM(html);
+  const body = dom.window.document.body.innerHTML;
+  const title = extractTitleFromHtml(body);
+  const openTasks = countOpenTasks(body);
   let { data, error } = await supabase
     .from("notes")
-    .update({ title, body: html, open_tasks: openTasks })
+    .update({ title, body, open_tasks: openTasks })
     .eq("id", id)
     .eq("user_id", user.id)
     .select("updated_at")
@@ -46,7 +48,7 @@ export async function saveNoteInline(
     // title column does not exist; retry without it
     ({ data, error } = await supabase
       .from("notes")
-      .update({ body: html, open_tasks: openTasks })
+      .update({ body, open_tasks: openTasks })
       .eq("id", id)
       .eq("user_id", user.id)
       .select("updated_at")

--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -31,16 +31,7 @@ export default async function NotePage({
   if (note.body == null) {
     console.warn(`Note ${id} has no body`);
   }
-
-  const escape = (s: string) =>
-    s
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;");
-
-  const html = body.trim().startsWith("<h1")
-    ? body
-    : `<h1>${escape(note.title ?? "")}</h1>${body}`;
+  const html = body;
 
   const openTasks = extractTasksFromHtml(body).filter(t => !t.checked).length;
   const created = note.created_at

--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -332,7 +332,6 @@ export default function InlineEditor({
 
   const runSave = React.useCallback(
     (html: string, opts?: { sync?: boolean }) => {
-      const docHtml = `<html><body>${html}</body></html>`;
       if (retryTimeout.current) {
         clearTimeout(retryTimeout.current);
         retryTimeout.current = null;
@@ -342,7 +341,7 @@ export default function InlineEditor({
         setStatus("saving");
         try {
           const data = new Blob(
-            [JSON.stringify({ id: noteId, html: docHtml })],
+            [JSON.stringify({ id: noteId, html })],
             { type: "application/json" },
           );
           navigator.sendBeacon("/api/save-note-inline", data);
@@ -351,7 +350,7 @@ export default function InlineEditor({
         return Promise.resolve({ openTasks: 0, updatedAt: null });
       }
       return saveWithRetry(
-        () => saveNoteInline(noteId, docHtml, { revalidate: false }),
+        () => saveNoteInline(noteId, html, { revalidate: false }),
         setStatus,
         attempts,
         retryTimeout,

--- a/supabase/migrations/20250401000000_strip_html_body_wrappers.sql
+++ b/supabase/migrations/20250401000000_strip_html_body_wrappers.sql
@@ -1,0 +1,7 @@
+-- Strip legacy <html><body> wrappers from notes.body
+UPDATE notes
+SET body = regexp_replace(
+        regexp_replace(body, '(?is)^<html><body>', ''),
+        '(?is)</body></html>$', ''
+    )
+WHERE body ~* '^<html><body>';


### PR DESCRIPTION
## Summary
- Save editor HTML without wrapping it in `<html><body>` during autosave and beacon flush
- Parse and persist only the inner HTML on `saveNoteInline`, computing title and open task count from it
- Remove redundant `<h1>` prepending in note page and add migration to strip existing wrappers from stored notes

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: Missing environment variable: NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68bb12553d3c832790066e8457b4cc53