### PR TITLE
Limit tasks card view to two columns

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -82,7 +82,7 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
           {groups.length === 0 ? (
             <p className="text-muted-foreground">{emptyMessage}</p>
           ) : view === 'card' ? (
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="grid gap-4 sm:grid-cols-2">
               {groups.map(group => (
                 <Card key={group.id}>
                   <CardHeader>


### PR DESCRIPTION
## Summary
- limit tasks card grid to two columns max by removing lg grid class

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: Missing environment variable: NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1499807883279ac6e8ffb6c73ea7