### PR TITLE
Align task checkbox with text

### DIFF
--- a/src/components/tasks/TaskRow.tsx
+++ b/src/components/tasks/TaskRow.tsx
@@ -38,8 +38,9 @@ export default function TaskRow({ task, noteId, line }: TaskRowProps) {
   }
 
   return (
-    <li className="flex items-center gap-2">
+    <li className="flex items-start gap-2">
       <Checkbox
+        className="mt-1"
         checked={task.done}
         onCheckedChange={() => handleToggle()}
         aria-label={task.done ? 'Mark task incomplete' : 'Mark task complete'}


### PR DESCRIPTION
## Summary
- Start task row items at top to align checkbox with text
- Offset checkbox with top margin for better alignment

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run typecheck` *(fails: Missing script "typecheck")*

------
https://chatgpt.com/codex/tasks/task_e_68bb196c83c083279785c60f5a96a123