### PR TITLE
style: pad editor and center note page

### DIFF
--- a/src/app/notes/[id]/NoteClient.tsx
+++ b/src/app/notes/[id]/NoteClient.tsx
@@ -51,7 +51,7 @@ export default function NoteClient({
     }
   }, [onDelete])
   return (
-    <div className="space-y-4 relative z-0">
+    <div className="max-w-screen-md mx-auto px-4 space-y-4 relative z-0">
       <NavButton
         href="/notes"
         variant="ghost"

--- a/src/components/editor/InlineEditor.tsx
+++ b/src/components/editor/InlineEditor.tsx
@@ -436,7 +436,7 @@ export default function InlineEditor({
       {editor && (
         <FloatingToolbar editor={editor} noteId={noteId} userId={userId} />
       )}
-      <div className="editor-prose prose prose-neutral dark:prose-invert max-w-none">
+      <div className="editor-prose prose prose-neutral dark:prose-invert max-w-none pb-6 prose-h1:mt-6 prose-h1:mb-4">
         <EditorContent editor={editor} />
       </div>
       <div className="text-xs text-muted-foreground text-right h-4">


### PR DESCRIPTION
## Summary
- center note page content and add horizontal padding
- pad editor bottom and normalize h1 margins for consistent spacing

## Testing
- `NEXT_PUBLIC_SUPABASE_URL="http://localhost" NEXT_PUBLIC_SUPABASE_ANON_KEY="anon" npm run build`
- `npm run lint`
- `npm test`
- `npm run typecheck` *(fails: Missing script "typecheck")*

------
https://chatgpt.com/codex/tasks/task_e_68bb1eb27bbc8327b6c4b689cb1874c2