### PR TITLE
feat: improve task card styling and filters

### DIFF
--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -84,7 +84,7 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
           ) : view === 'card' ? (
             <div className="grid gap-4 sm:grid-cols-2">
               {groups.map(group => (
-                <Card key={group.id}>
+                <Card key={group.id} className="hover:shadow-sm transition">
                   <CardHeader>
                     <CardTitle>
                       <NavButton
@@ -92,7 +92,9 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
                         variant="link"
                         className="p-0 h-auto font-medium underline"
                       >
-                        {group.title}
+                        <span className="truncate block max-w-[12rem]">
+                          {group.title}
+                        </span>
                       </NavButton>
                     </CardTitle>
                   </CardHeader>

--- a/src/components/tasks/TasksFilters.tsx
+++ b/src/components/tasks/TasksFilters.tsx
@@ -35,7 +35,7 @@ export default function TasksFilters({ notes, tags, children }: TasksFiltersProp
 
   return (
     <div className="mb-4 space-y-4">
-      <div className="flex items-center gap-2">
+      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2">
         {children}
         <button
           type="button"


### PR DESCRIPTION
## Summary
- enhance task card view with hover transition and truncated titles
- stack task filter controls vertically on small screens

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck` *(fails: Missing script: "typecheck")*
- `npm run build` *(fails: Missing environment variable: NEXT_PUBLIC_SUPABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe9757efc83278fce99f5592a8531