### PR TITLE
Improve mobile tap targets across notes and tasks

### DIFF
--- a/src/app/notes/[id]/NoteClient.tsx
+++ b/src/app/notes/[id]/NoteClient.tsx
@@ -57,7 +57,7 @@ export default function NoteClient({
         variant="ghost"
         size="icon"
         aria-label="Go back"
-        className="md:hidden"
+        className="md:hidden px-2"
       >
         <ArrowLeft className="h-5 w-5" />
       </NavButton>

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -84,7 +84,7 @@ export default async function TasksPage({ searchParams }: { searchParams: Promis
           ) : view === 'card' ? (
             <div className="grid gap-4 sm:grid-cols-2">
               {groups.map(group => (
-                <Card key={group.id} className="hover:shadow-sm transition">
+                <Card key={group.id} className="hover:shadow-sm transition w-full">
                   <CardHeader>
                     <CardTitle>
                       <NavButton

--- a/src/components/editor/FloatingToolbar.tsx
+++ b/src/components/editor/FloatingToolbar.tsx
@@ -94,7 +94,8 @@ export function FloatingToolbar({
       <div className="flex items-center gap-1 rounded-md border bg-background p-1 shadow-md">
         <Button
           type="button"
-          size="icon"
+          size="sm"
+          className="p-2"
           variant={editor.isActive("bold") ? "default" : "ghost"}
           onClick={handleBold}
           onKeyDown={(e) => {
@@ -108,7 +109,8 @@ export function FloatingToolbar({
         </Button>
         <Button
           type="button"
-          size="icon"
+          size="sm"
+          className="p-2"
           variant={editor.isActive("italic") ? "default" : "ghost"}
           onClick={() => editor.chain().focus().toggleItalic().run()}
           onKeyDown={(e) => {
@@ -122,7 +124,8 @@ export function FloatingToolbar({
         </Button>
         <Button
           type="button"
-          size="icon"
+          size="sm"
+          className="p-2"
           variant={
             editor.isActive("heading", { level: 1 }) ? "default" : "ghost"
           }
@@ -140,7 +143,8 @@ export function FloatingToolbar({
         </Button>
         <Button
           type="button"
-          size="icon"
+          size="sm"
+          className="p-2"
           variant={
             editor.isActive("heading", { level: 2 }) ? "default" : "ghost"
           }
@@ -158,7 +162,8 @@ export function FloatingToolbar({
         </Button>
         <Button
           type="button"
-          size="icon"
+          size="sm"
+          className="p-2"
           variant={
             editor.isActive("heading", { level: 3 }) ? "default" : "ghost"
           }
@@ -176,7 +181,8 @@ export function FloatingToolbar({
         </Button>
         <Button
           type="button"
-          size="icon"
+          size="sm"
+          className="p-2"
           variant={editor.isActive("bulletList") ? "default" : "ghost"}
           onClick={() => editor.chain().focus().toggleBulletList().run()}
           onKeyDown={(e) => {
@@ -190,7 +196,8 @@ export function FloatingToolbar({
         </Button>
         <Button
           type="button"
-          size="icon"
+          size="sm"
+          className="p-2"
           variant={editor.isActive("orderedList") ? "default" : "ghost"}
           onClick={() => editor.chain().focus().toggleOrderedList().run()}
           onKeyDown={(e) => {
@@ -204,7 +211,8 @@ export function FloatingToolbar({
         </Button>
         <Button
           type="button"
-          size="icon"
+          size="sm"
+          className="p-2"
           variant={editor.isActive("taskList") ? "default" : "ghost"}
           onClick={handleToggleTaskList}
           onKeyDown={(e) => {
@@ -218,7 +226,8 @@ export function FloatingToolbar({
         </Button>
         <Button
           type="button"
-          size="icon"
+          size="sm"
+          className="p-2"
           variant={editor.isActive("blockquote") ? "default" : "ghost"}
           onClick={() => editor.chain().focus().toggleBlockquote().run()}
           onKeyDown={(e) => {

--- a/src/components/tasks/TaskRow.tsx
+++ b/src/components/tasks/TaskRow.tsx
@@ -53,7 +53,7 @@ export default function TaskRow({ task, noteId, line }: TaskRowProps) {
         onChange={handleDueChange}
         onClear={() => handleDueChange('')}
         variant="link"
-        className="h-auto p-0 text-blue-600 hover:underline dark:text-blue-500"
+        className="h-6 px-2 text-blue-600 hover:underline dark:text-blue-500"
       >
         {label}
       </DateFilterTrigger>


### PR DESCRIPTION
## Summary
- enlarge back navigation hit area on note detail view
- make editor toolbar buttons touch-friendly
- ensure task cards and date picker controls fill small viewports

## Testing
- `npm run lint`
- `npm test`
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc539b12fc8327b2b32bd802fc9933