### PR TITLE
Filter empty notes and revalidate after auto delete

### DIFF
--- a/src/app/notes/[id]/page.tsx
+++ b/src/app/notes/[id]/page.tsx
@@ -3,6 +3,7 @@ export const dynamic = "force-dynamic";
 import { supabaseServer } from "@/lib/supabase-server";
 import { redirect } from "next/navigation";
 import { deleteNote } from "@/app/actions";
+import { revalidatePath } from "next/cache";
 import NoteClient from "./NoteClient";
 import { extractTasksFromHtml } from "@/lib/taskparse";
 
@@ -47,6 +48,7 @@ export default async function NotePage({
   async function onDelete() {
     "use server";
     await deleteNote(noteId);
+    revalidatePath("/notes");
     redirect("/notes");
   }
 

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -10,6 +10,8 @@ import { NavButton } from '@/components/NavButton'
 import { NotesClient } from './NotesClient'
 import { extractTitleFromHtml } from '@/lib/note'
 
+const EMPTY_HTML = '<h1></h1>'
+
 export default async function NotesPage() {
   const supabase = await supabaseServer()
   const { data: { user } } = await supabase.auth.getUser()
@@ -23,7 +25,7 @@ export default async function NotesPage() {
   const enriched: Note[] = (notes ?? [])
     .filter(n => {
       const body = (n.body ?? '').trim()
-      return body !== '' && body !== '<h1></h1>'
+      return body !== '' && body !== EMPTY_HTML
     })
       .map(n => ({
         id: n.id,


### PR DESCRIPTION
## Summary
- Exclude `<h1></h1>` placeholder notes from the notes list
- Revalidate the notes route after auto-deleting a note to keep the list fresh

## Testing
- `npm run lint`
- `npm test`
- `NEXT_PUBLIC_SUPABASE_URL=http://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc5da286a48327bf7957bfa722f29c