### PR TITLE
Add privacy policy and terms of service static pages

### DIFF
--- a/public/legal/privacy.html
+++ b/public/legal/privacy.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Privacy Policy</title>
+</head>
+<body>
+  <h1>Privacy Policy</h1>
+  <p>Effective date: March 15, 2025.</p>
+  <p>We value your privacy and are committed to protecting your personal information.</p>
+  <h2>Information We Collect</h2>
+  <p>We may collect the following information:</p>
+  <ul>
+    <li>Contact details such as email address.</li>
+    <li>Usage data including pages visited and interactions.</li>
+  </ul>
+  <h2>How We Use Information</h2>
+  <p>Your information helps us to:</p>
+  <ul>
+    <li>Provide and maintain our services.</li>
+    <li>Improve user experience.</li>
+    <li>Communicate with you about updates.</li>
+  </ul>
+  <h2>Your Choices</h2>
+  <p>You may contact us to access, correct, or delete your personal data.</p>
+  <h2>Contact Us</h2>
+  <p>If you have questions about this policy, email <a href="mailto:privacy@stratella.example">privacy@stratella.example</a>.</p>
+</body>
+</html>

--- a/public/legal/tos.html
+++ b/public/legal/tos.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Terms of Service</title>
+</head>
+<body>
+  <h1>Terms of Service</h1>
+  <p>Effective date: March 15, 2025.</p>
+  <p>By accessing or using Stratella, you agree to the following terms.</p>
+  <h2>Use of Service</h2>
+  <ul>
+    <li>You must be at least 13 years old to use the service.</li>
+    <li>Do not misuse or interfere with the service.</li>
+  </ul>
+  <h2>Accounts</h2>
+  <ul>
+    <li>You are responsible for maintaining the security of your account.</li>
+    <li>Notify us of unauthorized use.</li>
+  </ul>
+  <h2>Termination</h2>
+  <p>We may suspend or terminate access if these terms are violated.</p>
+  <h2>Disclaimer</h2>
+  <p>The service is provided "as is" without warranties.</p>
+  <h2>Contact</h2>
+  <p>For questions about these terms, email <a href="mailto:legal@stratella.example">legal@stratella.example</a>.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `/public/legal/privacy.html` with accessible privacy policy
- add `/public/legal/tos.html` with accessible terms of service

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck` *(fails: Missing script "typecheck")*
- `npm run build` *(fails: Missing env var NEXT_PUBLIC_SUPABASE_URL)*
- `curl -I http://localhost:3000/legal/privacy.html`
- `curl -I http://localhost:3000/legal/tos.html`


------
https://chatgpt.com/codex/tasks/task_e_68c09320bbc883279cdce50ce837805c