### PR TITLE
feat: add static privacy and terms pages

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,11 @@
+import { readFile } from 'fs/promises'
+import path from 'path'
+
+export const revalidate = false
+
+export default async function PrivacyPage() {
+  const filePath = path.join(process.cwd(), 'public', 'legal', 'privacy.html')
+  const html = await readFile(filePath, 'utf8')
+  const body = html.match(/<body>([\s\S]*?)<\/body>/i)?.[1] ?? html
+  return <article dangerouslySetInnerHTML={{ __html: body }} />
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,11 @@
+import { readFile } from 'fs/promises'
+import path from 'path'
+
+export const revalidate = false
+
+export default async function TermsPage() {
+  const filePath = path.join(process.cwd(), 'public', 'legal', 'tos.html')
+  const html = await readFile(filePath, 'utf8')
+  const body = html.match(/<body>([\s\S]*?)<\/body>/i)?.[1] ?? html
+  return <article dangerouslySetInnerHTML={{ __html: body }} />
+}


### PR DESCRIPTION
## Summary
- add static /privacy page rendering `public/legal/privacy.html`
- add static /terms page rendering `public/legal/tos.html`

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck` (fails: Missing script)
- `npm run build`
- `curl -sS http://localhost:3000/privacy | grep -o 'Privacy Policy' | head -n 20`
- `curl -sS http://localhost:3000/terms | grep -o 'Terms of Service' | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c094807fe08327912abb507e513c1a