### PR TITLE
feat: add footer for public pages

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,8 @@
 import './globals.css'
 import type { Metadata } from 'next'
 import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import { supabaseServer } from '@/lib/supabase-server'
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://stratella.vercel.app'),
@@ -14,12 +16,18 @@ export const metadata: Metadata = {
   twitter: { card: 'summary_large_image' },
 }
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const supabase = supabaseServer()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="bg-[radial-gradient(60%_40%_at_50%_-10%,hsl(var(--primary)/0.08),transparent)] bg-background text-foreground">
         <Header />
         <main className="mx-auto max-w-5xl p-4">{children}</main>
+        {!session && <Footer />}
       </body>
     </html>
   )

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link'
+
+export default function Footer() {
+  return (
+    <footer className="border-t bg-background">
+      <div className="mx-auto max-w-5xl px-4 py-6">
+        <div className="flex flex-col items-center gap-4 sm:flex-row sm:justify-between">
+          <p className="text-sm text-muted-foreground">&copy; {new Date().getFullYear()} Stratella</p>
+          <nav className="flex flex-col items-center gap-2 sm:flex-row sm:gap-4">
+            <Link
+              href="https://github.com/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              GitHub
+            </Link>
+            <Link
+              href="/privacy"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Privacy Policy
+            </Link>
+            <Link
+              href="/terms"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Terms of Service
+            </Link>
+          </nav>
+        </div>
+      </div>
+    </footer>
+  )
+}
+


### PR DESCRIPTION
## Summary
- add responsive, accessible footer
- render footer only for unauthenticated sessions

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck` *(fails: Missing script "typecheck")*
- `export NEXT_PUBLIC_SUPABASE_URL="http://localhost" NEXT_PUBLIC_SUPABASE_ANON_KEY="anon" && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c096b616e08327be4872a63befba98