### PR TITLE
feat(auth): add tos and privacy links

### DIFF
--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -187,6 +187,54 @@ export default function SignInForm() {
         )}
       </div>
 
+      <div className="text-center text-xs text-muted-foreground">
+        {mode === 'sign_up' ? (
+          <>
+            By signing up, you agree to our{' '}
+            <a
+              href="/terms"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-4"
+            >
+              Terms of Service
+            </a>{' '}
+            and{' '}
+            <a
+              href="/privacy"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-4"
+            >
+              Privacy Policy
+            </a>
+            .
+          </>
+        ) : (
+          <>
+            By signing in, you agree to our{' '}
+            <a
+              href="/terms"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-4"
+            >
+              Terms of Service
+            </a>{' '}
+            and{' '}
+            <a
+              href="/privacy"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline underline-offset-4"
+            >
+              Privacy Policy
+            </a>
+            .
+          </>
+        )}
+      </div>
+
       {err && <p className="text-sm text-destructive text-center">{err}</p>}
       {msg && <p className="text-sm text-muted-foreground text-center">{msg}</p>}
     </form>


### PR DESCRIPTION
## Summary
- note Terms of Service and Privacy Policy on sign up and sign in

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck` *(fails: Missing script "typecheck")*
- `npm run build` *(fails: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables required)*

------
https://chatgpt.com/codex/tasks/task_e_68c0984a9ff88327bf86f25c5f601c3e