### PR TITLE
test: add footer and sign-up legal link tests

### DIFF
--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+;(globalThis as unknown as { React: typeof React }).React = React
+import { render } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a {...props}>{children}</a>
+  ),
+}))
+
+import Footer from '../Footer'
+
+describe('Footer', () => {
+  it('renders legal links with target="_blank"', () => {
+    const { getByRole } = render(<Footer />)
+
+    const privacy = getByRole('link', { name: 'Privacy Policy' }) as HTMLAnchorElement
+    expect(privacy.getAttribute('href')).toBe('/privacy')
+    expect(privacy.getAttribute('target')).toBe('_blank')
+
+    const terms = getByRole('link', { name: 'Terms of Service' }) as HTMLAnchorElement
+    expect(terms.getAttribute('href')).toBe('/terms')
+    expect(terms.getAttribute('target')).toBe('_blank')
+  })
+})

--- a/src/components/__tests__/SignInFormLegal.test.tsx
+++ b/src/components/__tests__/SignInFormLegal.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+;(globalThis as unknown as { React: typeof React }).React = React
+import { render, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+}))
+
+vi.mock('@/lib/supabase-client', () => ({
+  supabaseClient: {
+    auth: {
+      signInWithPassword: vi.fn(),
+      signUp: vi.fn(),
+      getSession: vi.fn(),
+      resetPasswordForEmail: vi.fn(),
+    },
+  },
+}))
+
+import SignInForm from '../auth/SignInForm'
+
+describe('SignInFormLegal', () => {
+  it('shows acknowledgement text with links in sign-up mode', () => {
+    const { getByRole, getByText } = render(<SignInForm />)
+
+    fireEvent.click(getByRole('button', { name: /sign up/i }))
+
+    getByText(/by signing up, you agree to our/i)
+
+    const terms = getByRole('link', { name: 'Terms of Service' }) as HTMLAnchorElement
+    expect(terms.getAttribute('href')).toBe('/terms')
+    expect(terms.getAttribute('target')).toBe('_blank')
+
+    const privacy = getByRole('link', { name: 'Privacy Policy' }) as HTMLAnchorElement
+    expect(privacy.getAttribute('href')).toBe('/privacy')
+    expect(privacy.getAttribute('target')).toBe('_blank')
+  })
+})


### PR DESCRIPTION
## Summary
- add Footer test to confirm legal links and new tab targeting
- add SignInForm test ensuring sign-up legal acknowledgement links

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck` *(fails: Missing script: "typecheck")*
- `NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=anon npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c099a0010083279d527cc4f9091592