### PR TITLE
docs: document legal pages and update instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,12 @@ Replace `<sample note body>` with the exact string defined in `src/app/api/init-
 
 - TipTap uses an `<h1>` block as the note title and removes the “Untitled Note” placeholder once typing begins.
 - Empty notes are automatically deleted when the editor blurs or the page unloads without any user input.
+
+## Legal
+
+Static Terms of Service and Privacy Policy pages are available at `/terms` and `/privacy`.
+These routes render the HTML in `public/legal/tos.html` and `public/legal/privacy.html`.
+Links to both pages appear in the footer and on the sign-in form and open in a new tab.
+
+To update the legal copy, edit the respective HTML files in `public/legal/`.
+Only the contents inside each file's `<body>` tag are injected into the page.

--- a/public/legal/README.md
+++ b/public/legal/README.md
@@ -1,0 +1,13 @@
+# Legal documents
+
+This directory contains the HTML shown on the `/terms` and `/privacy` routes.
+
+## Updating copy
+
+- `tos.html` feeds the Terms of Service at `/terms`.
+- `privacy.html` feeds the Privacy Policy at `/privacy`.
+
+Only the content inside each file's `<body>` tag is rendered. Update the text in these files to modify the live pages.
+
+If you add new assets, keep filenames and paths stable and run the test suite to ensure links still work.
+


### PR DESCRIPTION
## Summary
- document Terms of Service and Privacy Policy routes and footer links
- add instructions for updating legal copy in `public/legal/`

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck` *(fails: Missing script "typecheck")*
- `npm run build` *(fails: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY required)*

------
https://chatgpt.com/codex/tasks/task_e_68c149b6656883278643d8870ce73b3e