### PR TITLE
Add keyboard shortcuts dialog and menu item

### DIFF
--- a/src/components/KeyboardShortcutsDialog.tsx
+++ b/src/components/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { Button } from "@/components/ui/button";
+
+interface KeyboardShortcutsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface Shortcut {
+  keys: string[];
+  description: string;
+}
+
+const shortcuts: Shortcut[] = [
+  { keys: ["?"], description: "Open this dialog" },
+  { keys: ["g", "t"], description: "Go to tasks" },
+  { keys: ["g", "n"], description: "Go to notes" },
+];
+
+export default function KeyboardShortcutsDialog({
+  open,
+  onOpenChange,
+}: KeyboardShortcutsDialogProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50" />
+        <Dialog.Content
+          role="dialog"
+          aria-label="Keyboard shortcuts"
+          className="fixed left-1/2 top-1/2 z-50 w-[90vw] max-w-md -translate-x-1/2 -translate-y-1/2 rounded-md bg-background p-6 shadow-lg"
+        >
+          <Dialog.Title className="text-lg font-medium">
+            Keyboard shortcuts
+          </Dialog.Title>
+          <Dialog.Description className="sr-only">
+            Global application keyboard shortcuts
+          </Dialog.Description>
+          <ul className="mt-4 space-y-2">
+            {shortcuts.map((s, i) => (
+              <li key={i} className="flex items-center gap-4 text-sm">
+                <span className="flex gap-1">
+                  {s.keys.map((k, idx) => (
+                    <kbd
+                      key={idx}
+                      className="rounded border bg-muted px-1 py-0.5 font-mono text-xs"
+                    >
+                      {k}
+                    </kbd>
+                  ))}
+                </span>
+                <span>{s.description}</span>
+              </li>
+            ))}
+          </ul>
+          <div className="mt-6 flex justify-end">
+            <Dialog.Close asChild>
+              <Button type="button" variant="outline">
+                Close
+              </Button>
+            </Dialog.Close>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -12,10 +12,12 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { supabaseClient } from "@/lib/supabase-client";
+import KeyboardShortcutsDialog from "@/components/KeyboardShortcutsDialog";
 
 export default function UserMenu() {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
 
   useEffect(() => {
     const {
@@ -38,32 +40,39 @@ export default function UserMenu() {
   }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button variant="outline">Account</Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem
-          onClick={signOut}
-          variant="destructive"
-          disabled={loading}
-        >
-          {loading ? "Signing out…" : "Sign out"}
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem asChild>
-          <Link href="/terms">Terms</Link>
-        </DropdownMenuItem>
-        <DropdownMenuItem asChild>
-          <Link href="/privacy">Privacy</Link>
-        </DropdownMenuItem>
-        <DropdownMenuItem asChild>
-          <Link href="/support">Support</Link>
-        </DropdownMenuItem>
-        <DropdownMenuItem onSelect={() => alert("Keyboard shortcuts")}>
-          Keyboard shortcuts
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="outline">Account</Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onClick={signOut}
+            variant="destructive"
+            disabled={loading}
+          >
+            {loading ? "Signing out…" : "Sign out"}
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem asChild>
+            <Link href="/terms">Terms</Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <Link href="/privacy">Privacy</Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <Link href="/support">Support</Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem onSelect={() => setShortcutsOpen(true)}>
+            Keyboard shortcuts
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <KeyboardShortcutsDialog
+        open={shortcutsOpen}
+        onOpenChange={setShortcutsOpen}
+      />
+    </>
   );
 }
+


### PR DESCRIPTION
## Summary
- add keyboard shortcuts dialog listing core app shortcuts
- link keyboard shortcut dialog from user menu

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables or supabaseUrl and supabaseKey are required)*

------
https://chatgpt.com/codex/tasks/task_e_68c4028c5384832792a11eae8d6b2cb5