### PR TITLE
docs: update terms of service

### DIFF
--- a/public/legal/tos.html
+++ b/public/legal/tos.html
@@ -1,28 +1,166 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>Terms of Service</title>
-</head>
-<body>
-  <h1>Terms of Service</h1>
-  <p>Effective date: March 15, 2025.</p>
-  <p>By accessing or using Stratella, you agree to the following terms.</p>
-  <h2>Use of Service</h2>
-  <ul>
-    <li>You must be at least 13 years old to use the service.</li>
-    <li>Do not misuse or interfere with the service.</li>
-  </ul>
-  <h2>Accounts</h2>
-  <ul>
-    <li>You are responsible for maintaining the security of your account.</li>
-    <li>Notify us of unauthorized use.</li>
-  </ul>
-  <h2>Termination</h2>
-  <p>We may suspend or terminate access if these terms are violated.</p>
-  <h2>Disclaimer</h2>
-  <p>The service is provided "as is" without warranties.</p>
-  <h2>Contact</h2>
-  <p>For questions about these terms, email <a href="mailto:legal@stratella.example">legal@stratella.example</a>.</p>
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Terms of Service</title>
+  </head>
+  <body>
+    <h1>Terms &amp; Conditions (Terms of Service)</h1>
+    <p><strong>Effective Date:</strong> August 9, 2025</p>
+    <p>
+      Welcome to Stratella. These Terms &amp; Conditions (the “Terms” or “Terms
+      of Service”) govern your access to and use of the Stratella web
+      application, websites, and related services (collectively, the
+      “Services”). By creating an account or using the Services, you agree to
+      these Terms and to our Privacy Policy.
+    </p>
+    <hr />
+    <h2>1. Accounts</h2>
+    <ul>
+      <li>
+        You must be at least 13 years old (or the age of majority in your
+        jurisdiction) to use the Services.
+      </li>
+      <li>
+        You are responsible for safeguarding your credentials and for all
+        activity under your account.
+      </li>
+      <li>
+        Notify us immediately at
+        <a href="mailto:support@stratella.app">support@stratella.app</a> if you
+        suspect unauthorized access.
+      </li>
+    </ul>
+    <h2>2. Your Content &amp; Ownership</h2>
+    <ul>
+      <li>
+        <strong>You retain ownership</strong> of all notes, tasks, files, and
+        other content you submit or create through the Services (“Your
+        Content”).
+      </li>
+      <li>
+        You grant Stratella a limited, non‑exclusive, revocable license to host,
+        process, and display Your Content
+        <strong>solely to operate and improve the Services</strong> (e.g.,
+        storage, backup, rendering, indexing for search).
+      </li>
+      <li>
+        We do <strong>not</strong> claim ownership over Your Content and we do
+        <strong>not</strong> sell Your Content or your personal information to
+        third parties.
+      </li>
+    </ul>
+    <h2>3. Data Use; No Sale of Data</h2>
+    <ul>
+      <li>
+        Stratella does <strong>not</strong> sell personal information (as “sell”
+        is defined under applicable privacy laws such as the CCPA/CPRA).
+      </li>
+      <li>
+        We may share limited data with service providers (e.g., hosting,
+        analytics, customer support) under contracts that restrict use of the
+        data to providing services to Stratella.
+      </li>
+    </ul>
+    <h2>4. Export &amp; Deletion</h2>
+    <ul>
+      <li>
+        <strong>Export:</strong> You may export Your Content (where features
+        exist) or contact
+        <a href="mailto:support@stratella.app">support@stratella.app</a> for
+        reasonable export assistance.
+      </li>
+      <li>
+        <strong>Deletion:</strong> You may delete Your Content at any time. You
+        may also request account deletion via in‑app controls (if available) or
+        by emailing
+        <a href="mailto:support@stratella.app">support@stratella.app</a>.
+      </li>
+      <li>
+        Upon verified request, Stratella will delete your account and personal
+        data from active systems <strong>within 30 days</strong>, subject to:
+        <ul>
+          <li>
+            (a) limited retention in backups and logs for security, continuity,
+            and legal compliance (typically purged on rolling cycles within
+            <strong>90 days</strong>), and
+          </li>
+          <li>
+            (b) retention required by law or to resolve disputes/enforce
+            agreements.
+          </li>
+        </ul>
+      </li>
+      <li>
+        We will instruct our contracted service providers to delete
+        corresponding data they process for Stratella, where applicable.
+      </li>
+    </ul>
+    <h2>5. Acceptable Use</h2>
+    <p>You agree not to:</p>
+    <ul>
+      <li>Use the Services for unlawful, infringing, or harmful activities;</li>
+      <li>Attempt to access accounts or data without authorization;</li>
+      <li>Interfere with or disrupt the Services or related infrastructure;</li>
+      <li>
+        Reverse engineer or create derivative works of the Services except where
+        allowed by law.
+      </li>
+    </ul>
+    <h2>6. Intellectual Property (Stratella Materials)</h2>
+    <p>
+      The Services, including software, UI, and branding, are owned by Stratella
+      or its licensors and are protected by IP laws. You may not use our
+      trademarks without permission.
+    </p>
+    <h2>7. Service Changes; Availability</h2>
+    <p>
+      We may modify or discontinue features. We strive for high availability but
+      do not guarantee the Services will be uninterrupted or error‑free.
+    </p>
+    <h2>8. Disclaimers</h2>
+    <p>
+      THE SERVICES ARE PROVIDED “AS IS” AND “AS AVAILABLE.” TO THE MAXIMUM
+      EXTENT PERMITTED BY LAW, STRATELLA DISCLAIMS ALL WARRANTIES, EXPRESS OR
+      IMPLIED, INCLUDING MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+      NON‑INFRINGEMENT.
+    </p>
+    <h2>9. Limitation of Liability</h2>
+    <p>
+      TO THE MAXIMUM EXTENT PERMITTED BY LAW, STRATELLA SHALL NOT BE LIABLE FOR
+      INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY
+      LOSS OF DATA OR PROFITS, ARISING OUT OF OR RELATED TO YOUR USE OF THE
+      SERVICES. IN ANY EVENT, STRATELLA’S TOTAL LIABILITY FOR CLAIMS RELATING TO
+      THE SERVICES SHALL NOT EXCEED THE AMOUNTS PAID BY YOU TO STRATELLA FOR THE
+      SERVICES IN THE <strong>12 MONTHS</strong> PRECEDING THE CLAIM.
+    </p>
+    <h2>10. Indemnification</h2>
+    <p>
+      You will indemnify and hold harmless Stratella and its affiliates,
+      officers, and employees from any claims arising from (a) Your Content, (b)
+      your misuse of the Services, or (c) your violation of these Terms or
+      applicable law.
+    </p>
+    <h2>11. Governing Law; Disputes</h2>
+    <p>
+      These Terms are governed by the laws of
+      <strong>[Insert State/Country]</strong>, without regard to
+      conflict‑of‑laws principles. Venue and jurisdiction for disputes shall lie
+      in the courts located in <strong>[Insert Venue]</strong>, unless
+      applicable law requires otherwise.
+    </p>
+    <h2>12. Changes to Terms</h2>
+    <p>
+      We may update these Terms from time to time. Material changes will be
+      posted with an updated effective date. Your continued use of the Services
+      after changes become effective constitutes acceptance.
+    </p>
+    <h2>13. Contact</h2>
+    <p>
+      Questions about these Terms:
+      <a href="mailto:support@stratella.app">support@stratella.app</a>
+    </p>
+    <hr />
+    <p><em>Last updated: August 9, 2025</em></p>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- replace Terms of Service HTML with updated Terms & Conditions effective August 9, 2025

## Testing
- `npm run lint`
- `npm test`
- `npm run typecheck` *(fails: Missing script "typecheck")*
- `npm run build` *(fails: NEXT_PUBLIC_SUPABASE_URL env vars missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c401fde5888327b72f424a055ddf2a