### PR TITLE
feat: add support link and page

### DIFF
--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,0 +1,17 @@
+export const metadata = { title: "Support" };
+
+export default function SupportPage() {
+  return (
+    <main className="prose mx-auto p-4">
+      <h1>Support</h1>
+      <p>
+        Need help? Contact us at{' '}
+        <a href="mailto:support@example.com">support@example.com</a>.
+      </p>
+      <p>
+        You can also browse our frequently asked questions to find common
+        answers.
+      </p>
+    </main>
+  );
+}

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -63,6 +63,9 @@ export default function UserMenu() {
           <DropdownMenuItem asChild>
             <Link href="/support">Support</Link>
           </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <Link href="mailto:support@example.com">Email support</Link>
+          </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setShortcutsOpen(true)}>
             Keyboard shortcuts
           </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- add email support link in user menu
- create basic support page with contact information

## Testing
- `npm run lint`
- `npm test`
- `NEXT_PUBLIC_SUPABASE_URL=https://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=example npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4056c71e883279fa7aca2d3c4da0c