### PR TITLE
docs: update privacy policy

### DIFF
--- a/public/legal/privacy.html
+++ b/public/legal/privacy.html
@@ -6,24 +6,57 @@
 </head>
 <body>
   <h1>Privacy Policy</h1>
-  <p>Effective date: March 15, 2025.</p>
-  <p>We value your privacy and are committed to protecting your personal information.</p>
-  <h2>Information We Collect</h2>
-  <p>We may collect the following information:</p>
+  <p><strong>Effective Date:</strong> August 9, 2025</p>
+  <p>Stratella ("we," "us," or "our") respects your privacy. This Privacy Policy explains how we collect, use, disclose, and protect information in connection with our web application and related services (the "Services").</p>
+  <hr />
+  <h2>1. Information We Collect</h2>
   <ul>
-    <li>Contact details such as email address.</li>
-    <li>Usage data including pages visited and interactions.</li>
+    <li><strong>Account Information:</strong> Email, name, and any profile details you provide.</li>
+    <li><strong>Your Content:</strong> Notes, tasks, files, and other data you create or upload. <strong>You retain ownership of Your Content.</strong></li>
+    <li><strong>Usage Data:</strong> Device/browser type, IP address, pages viewed, actions taken, timestamps, and similar diagnostic data.</li>
+    <li><strong>Cookies/Similar Technologies:</strong> Used for authentication, preferences, and performance.</li>
   </ul>
-  <h2>How We Use Information</h2>
-  <p>Your information helps us to:</p>
+  <h2>2. How We Use Information</h2>
+  <p>We process information to:</p>
   <ul>
-    <li>Provide and maintain our services.</li>
-    <li>Improve user experience.</li>
-    <li>Communicate with you about updates.</li>
+    <li>Provide and maintain the Services (e.g., hosting, syncing, rendering content);</li>
+    <li>Authenticate users, secure accounts, and prevent abuse;</li>
+    <li>Communicate with you (service notices, security alerts, support);</li>
+    <li>Analyze usage to improve reliability and features;</li>
+    <li>Comply with legal obligations.</li>
   </ul>
-  <h2>Your Choices</h2>
-  <p>You may contact us to access, correct, or delete your personal data.</p>
-  <h2>Contact Us</h2>
-  <p>If you have questions about this policy, email <a href="mailto:privacy@stratella.example">privacy@stratella.example</a>.</p>
+  <h2>3. Sharing of Information</h2>
+  <p>We do <strong>not</strong> sell your personal information. We may share limited data with:</p>
+  <ul>
+    <li><strong>Service Providers:</strong> Hosting, database, analytics, email, and customer support vendors bound by contracts to use data solely to provide services to Stratella;</li>
+    <li><strong>Legal/Compliance:</strong> Where required by law or to protect rights, property, or safety;</li>
+    <li><strong>Business Transfers:</strong> If we engage in a merger, acquisition, or asset sale, your information may be transferred with appropriate safeguards.</li>
+  </ul>
+  <h2>4. Data Retention, Export, and Deletion</h2>
+  <ul>
+    <li><strong>Retention:</strong> We retain personal data while your account is active or as needed to provide the Services.</li>
+    <li><strong>Export:</strong> You can export Your Content (where features exist) or contact <a href="mailto:support@stratella.app">support@stratella.app</a> for reasonable export assistance.</li>
+    <li><strong>Deletion:</strong> You may delete Your Content and/or request account deletion at any time via in‑app controls (if available) or email <a href="mailto:support@stratella.app">support@stratella.app</a>.
+      <ul>
+        <li>Upon verified request, we delete personal data from active systems within <strong>30 days</strong>; residual copies may remain in encrypted backups or logs for a limited period (typically <strong>up to 90 days</strong>) and will be purged on their normal cycles.</li>
+        <li>We may retain information as required by law, to resolve disputes, or enforce agreements.</li>
+        <li>We will instruct our service providers to delete corresponding data they process for Stratella, where applicable.</li>
+      </ul>
+    </li>
+  </ul>
+  <h2>5. Security</h2>
+  <p>We implement administrative, technical, and physical safeguards designed to protect personal data. No method of transmission or storage is 100% secure.</p>
+  <h2>6. Your Rights</h2>
+  <p>Depending on your location, you may have rights to access, correct, delete, object to processing, or obtain a copy of your data. Contact <a href="mailto:support@stratella.app">support@stratella.app</a> to exercise these rights. We may need to verify your identity before fulfilling requests.</p>
+  <h2>7. International Data Transfers</h2>
+  <p>If you access the Services from outside the country where our systems are hosted, your information may be transferred across borders subject to appropriate safeguards where required by law.</p>
+  <h2>8. Children’s Privacy</h2>
+  <p>The Services are not directed to children under 13 (or the minimum age in your jurisdiction). We do not knowingly collect information from children.</p>
+  <h2>9. Changes to this Policy</h2>
+  <p>We may update this Privacy Policy periodically. Material changes will be posted with an updated effective date.</p>
+  <h2>10. Contact</h2>
+  <p>Questions or requests regarding privacy: <a href="mailto:support@stratella.app">support@stratella.app</a></p>
+  <hr />
+  <p><em>Last updated: August 9, 2025</em></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace privacy policy HTML with detailed policy effective August 9, 2025

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables are required)*

------
https://chatgpt.com/codex/tasks/task_e_68c4071fc2dc83278ccdc03f186764a1