### PR TITLE
test: add UserMenu dropdown tests

### DIFF
--- a/src/components/__tests__/UserMenu.test.tsx
+++ b/src/components/__tests__/UserMenu.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+;(globalThis as unknown as { React: typeof React }).React = React
+import { render, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & React.ComponentProps<'div'>) => (
+    <div role="menuitem" {...props}>
+      {children}
+    </div>
+  ),
+  DropdownMenuSeparator: () => <div role="separator" />,
+}))
+
+vi.mock('@/lib/supabase-client', () => {
+  const signOut = vi.fn().mockResolvedValue(undefined)
+  return {
+    supabaseClient: {
+      auth: {
+        signOut,
+        onAuthStateChange: vi.fn().mockReturnValue({
+          data: { subscription: { unsubscribe: vi.fn() } },
+        }),
+      },
+    },
+  }
+})
+
+const replace = vi.fn()
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace }),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a {...props}>{children}</a>
+  ),
+}))
+
+import { supabaseClient } from '@/lib/supabase-client'
+import UserMenu from '../UserMenu'
+
+describe('UserMenu', () => {
+  it('renders menu items and signs out', async () => {
+    const { getByRole, getByText } = render(<UserMenu />)
+
+    fireEvent.click(getByRole('button', { name: 'Account' }))
+
+    expect(getByText('Sign out')).toBeTruthy()
+    expect(getByText('Terms')).toBeTruthy()
+    expect(getByText('Privacy')).toBeTruthy()
+    expect(getByText('Support')).toBeTruthy()
+    expect(getByText('Email support')).toBeTruthy()
+    expect(getByText('Keyboard shortcuts')).toBeTruthy()
+
+    fireEvent.click(getByText('Sign out'))
+    await waitFor(() => expect(supabaseClient.auth.signOut).toHaveBeenCalled())
+  })
+})
+


### PR DESCRIPTION
## Summary
- add test ensuring UserMenu shows expected links and calls Supabase sign out

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck` *(fails: Missing script: "typecheck")*
- `npm run build` *(fails: either NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables or supabaseUrl and supabaseKey are required!)*

------
https://chatgpt.com/codex/tasks/task_e_68c4096972248327b69ad14675d9e41b