### PR TITLE
chore: update support email addresses

### DIFF
--- a/public/legal/privacy.html
+++ b/public/legal/privacy.html
@@ -35,8 +35,8 @@
   <h2>4. Data Retention, Export, and Deletion</h2>
   <ul>
     <li><strong>Retention:</strong> We retain personal data while your account is active or as needed to provide the Services.</li>
-    <li><strong>Export:</strong> You can export Your Content (where features exist) or contact <a href="mailto:support@stratella.app">support@stratella.app</a> for reasonable export assistance.</li>
-    <li><strong>Deletion:</strong> You may delete Your Content and/or request account deletion at any time via in‑app controls (if available) or email <a href="mailto:support@stratella.app">support@stratella.app</a>.
+    <li><strong>Export:</strong> You can export Your Content (where features exist) or contact <a href="mailto:support@canvasinnovations.io">support@canvasinnovations.io</a> for reasonable export assistance.</li>
+    <li><strong>Deletion:</strong> You may delete Your Content and/or request account deletion at any time via in‑app controls (if available) or email <a href="mailto:support@canvasinnovations.io">support@canvasinnovations.io</a>.
       <ul>
         <li>Upon verified request, we delete personal data from active systems within <strong>30 days</strong>; residual copies may remain in encrypted backups or logs for a limited period (typically <strong>up to 90 days</strong>) and will be purged on their normal cycles.</li>
         <li>We may retain information as required by law, to resolve disputes, or enforce agreements.</li>
@@ -47,7 +47,7 @@
   <h2>5. Security</h2>
   <p>We implement administrative, technical, and physical safeguards designed to protect personal data. No method of transmission or storage is 100% secure.</p>
   <h2>6. Your Rights</h2>
-  <p>Depending on your location, you may have rights to access, correct, delete, object to processing, or obtain a copy of your data. Contact <a href="mailto:support@stratella.app">support@stratella.app</a> to exercise these rights. We may need to verify your identity before fulfilling requests.</p>
+  <p>Depending on your location, you may have rights to access, correct, delete, object to processing, or obtain a copy of your data. Contact <a href="mailto:support@canvasinnovations.io">support@canvasinnovations.io</a> to exercise these rights. We may need to verify your identity before fulfilling requests.</p>
   <h2>7. International Data Transfers</h2>
   <p>If you access the Services from outside the country where our systems are hosted, your information may be transferred across borders subject to appropriate safeguards where required by law.</p>
   <h2>8. Children’s Privacy</h2>
@@ -55,7 +55,7 @@
   <h2>9. Changes to this Policy</h2>
   <p>We may update this Privacy Policy periodically. Material changes will be posted with an updated effective date.</p>
   <h2>10. Contact</h2>
-  <p>Questions or requests regarding privacy: <a href="mailto:support@stratella.app">support@stratella.app</a></p>
+  <p>Questions or requests regarding privacy: <a href="mailto:support@canvasinnovations.io">support@canvasinnovations.io</a></p>
   <hr />
   <p><em>Last updated: August 9, 2025</em></p>
 </body>

--- a/public/legal/tos.html
+++ b/public/legal/tos.html
@@ -27,7 +27,7 @@
       </li>
       <li>
         Notify us immediately at
-        <a href="mailto:support@stratella.app">support@stratella.app</a> if you
+        <a href="mailto:support@canvasinnovations.io">support@canvasinnovations.io</a> if you
         suspect unauthorized access.
       </li>
     </ul>
@@ -67,14 +67,14 @@
       <li>
         <strong>Export:</strong> You may export Your Content (where features
         exist) or contact
-        <a href="mailto:support@stratella.app">support@stratella.app</a> for
+        <a href="mailto:support@canvasinnovations.io">support@canvasinnovations.io</a> for
         reasonable export assistance.
       </li>
       <li>
         <strong>Deletion:</strong> You may delete Your Content at any time. You
         may also request account deletion via in‑app controls (if available) or
         by emailing
-        <a href="mailto:support@stratella.app">support@stratella.app</a>.
+        <a href="mailto:support@canvasinnovations.io">support@canvasinnovations.io</a>.
       </li>
       <li>
         Upon verified request, Stratella will delete your account and personal
@@ -158,7 +158,7 @@
     <h2>13. Contact</h2>
     <p>
       Questions about these Terms:
-      <a href="mailto:support@stratella.app">support@stratella.app</a>
+      <a href="mailto:support@canvasinnovations.io">support@canvasinnovations.io</a>
     </p>
     <hr />
     <p><em>Last updated: August 9, 2025</em></p>

--- a/src/app/support/__tests__/SupportPage.test.tsx
+++ b/src/app/support/__tests__/SupportPage.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+;(globalThis as unknown as { React: typeof React }).React = React
+import { render } from '@testing-library/react'
+import SupportPage from '../page'
+
+test('shows support email link', () => {
+  const { getByRole } = render(<SupportPage />)
+  const email = getByRole('link', { name: 'support@canvasinnovations.io' }) as HTMLAnchorElement
+  expect(email.getAttribute('href')).toBe('mailto:support@canvasinnovations.io')
+})

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -6,7 +6,7 @@ export default function SupportPage() {
       <h1>Support</h1>
       <p>
         Need help? Contact us at{' '}
-        <a href="mailto:support@example.com">support@example.com</a>.
+        <a href="mailto:support@canvasinnovations.io">support@canvasinnovations.io</a>.
       </p>
       <p>
         You can also browse our frequently asked questions to find common

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -64,7 +64,7 @@ export default function UserMenu() {
             <Link href="/support">Support</Link>
           </DropdownMenuItem>
           <DropdownMenuItem asChild>
-            <Link href="mailto:support@example.com">Email support</Link>
+            <Link href="mailto:support@canvasinnovations.io">Email support</Link>
           </DropdownMenuItem>
           <DropdownMenuItem onSelect={() => setShortcutsOpen(true)}>
             Keyboard shortcuts

--- a/src/components/__tests__/UserMenu.test.tsx
+++ b/src/components/__tests__/UserMenu.test.tsx
@@ -61,8 +61,14 @@ describe('UserMenu', () => {
     expect(getByText('Terms')).toBeTruthy()
     expect(getByText('Privacy')).toBeTruthy()
     expect(getByText('Support')).toBeTruthy()
-    expect(getByText('Email support')).toBeTruthy()
     expect(getByText('Keyboard shortcuts')).toBeTruthy()
+
+    const emailLink = getByRole('link', {
+      name: 'Email support',
+    }) as HTMLAnchorElement
+    expect(emailLink.getAttribute('href')).toBe(
+      'mailto:support@canvasinnovations.io'
+    )
 
     fireEvent.click(getByText('Sign out'))
     await waitFor(() => expect(supabaseClient.auth.signOut).toHaveBeenCalled())


### PR DESCRIPTION
## Summary
- update support contact to support@canvasinnovations.io in support page, user menu, and legal docs
- verify user menu email link in tests and add support page test

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: either NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables or supabaseUrl and supabaseKey are required)*
- `npm run typecheck` *(fails: Missing script: "typecheck")*


------
https://chatgpt.com/codex/tasks/task_e_68c44b142870832792b561aad9cf0662