### PR TITLE
style: improve privacy policy formatting

### DIFF
--- a/public/legal/privacy.html
+++ b/public/legal/privacy.html
@@ -1,62 +1,187 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>Privacy Policy</title>
-</head>
-<body>
-  <h1>Privacy Policy</h1>
-  <p><strong>Effective Date:</strong> August 9, 2025</p>
-  <p>Stratella ("we," "us," or "our") respects your privacy. This Privacy Policy explains how we collect, use, disclose, and protect information in connection with our web application and related services (the "Services").</p>
-  <hr />
-  <h2>1. Information We Collect</h2>
-  <ul>
-    <li><strong>Account Information:</strong> Email, name, and any profile details you provide.</li>
-    <li><strong>Your Content:</strong> Notes, tasks, files, and other data you create or upload. <strong>You retain ownership of Your Content.</strong></li>
-    <li><strong>Usage Data:</strong> Device/browser type, IP address, pages viewed, actions taken, timestamps, and similar diagnostic data.</li>
-    <li><strong>Cookies/Similar Technologies:</strong> Used for authentication, preferences, and performance.</li>
-  </ul>
-  <h2>2. How We Use Information</h2>
-  <p>We process information to:</p>
-  <ul>
-    <li>Provide and maintain the Services (e.g., hosting, syncing, rendering content);</li>
-    <li>Authenticate users, secure accounts, and prevent abuse;</li>
-    <li>Communicate with you (service notices, security alerts, support);</li>
-    <li>Analyze usage to improve reliability and features;</li>
-    <li>Comply with legal obligations.</li>
-  </ul>
-  <h2>3. Sharing of Information</h2>
-  <p>We do <strong>not</strong> sell your personal information. We may share limited data with:</p>
-  <ul>
-    <li><strong>Service Providers:</strong> Hosting, database, analytics, email, and customer support vendors bound by contracts to use data solely to provide services to Stratella;</li>
-    <li><strong>Legal/Compliance:</strong> Where required by law or to protect rights, property, or safety;</li>
-    <li><strong>Business Transfers:</strong> If we engage in a merger, acquisition, or asset sale, your information may be transferred with appropriate safeguards.</li>
-  </ul>
-  <h2>4. Data Retention, Export, and Deletion</h2>
-  <ul>
-    <li><strong>Retention:</strong> We retain personal data while your account is active or as needed to provide the Services.</li>
-    <li><strong>Export:</strong> You can export Your Content (where features exist) or contact <a href="mailto:support@canvasinnovations.io">support@canvasinnovations.io</a> for reasonable export assistance.</li>
-    <li><strong>Deletion:</strong> You may delete Your Content and/or request account deletion at any time via in‑app controls (if available) or email <a href="mailto:support@canvasinnovations.io">support@canvasinnovations.io</a>.
-      <ul>
-        <li>Upon verified request, we delete personal data from active systems within <strong>30 days</strong>; residual copies may remain in encrypted backups or logs for a limited period (typically <strong>up to 90 days</strong>) and will be purged on their normal cycles.</li>
-        <li>We may retain information as required by law, to resolve disputes, or enforce agreements.</li>
-        <li>We will instruct our service providers to delete corresponding data they process for Stratella, where applicable.</li>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Privacy Policy</title>
+  </head>
+  <body>
+    <section class="mb-8">
+      <h1>Privacy Policy</h1>
+      <p class="mb-4"><strong>Effective Date:</strong> August 9, 2025</p>
+      <p class="mb-4">
+        Stratella ("we," "us," or "our") respects your privacy. This Privacy
+        Policy explains how we collect, use, disclose, and protect information
+        in connection with our web application and related services (the
+        "Services").
+      </p>
+    </section>
+
+    <hr class="my-6" />
+
+    <section class="mb-8">
+      <h2>1. Information We Collect</h2>
+      <ul class="list-disc pl-6 space-y-2 mb-4">
+        <li>
+          <strong>Account Information:</strong> Email, name, and any profile
+          details you provide.
+        </li>
+        <li>
+          <strong>Your Content:</strong> Notes, tasks, files, and other data you
+          create or upload. <strong>You retain ownership of Your Content.</strong>
+        </li>
+        <li>
+          <strong>Usage Data:</strong> Device/browser type, IP address, pages
+          viewed, actions taken, timestamps, and similar diagnostic data.
+        </li>
+        <li>
+          <strong>Cookies/Similar Technologies:</strong> Used for
+          authentication, preferences, and performance.
+        </li>
       </ul>
-    </li>
-  </ul>
-  <h2>5. Security</h2>
-  <p>We implement administrative, technical, and physical safeguards designed to protect personal data. No method of transmission or storage is 100% secure.</p>
-  <h2>6. Your Rights</h2>
-  <p>Depending on your location, you may have rights to access, correct, delete, object to processing, or obtain a copy of your data. Contact <a href="mailto:support@canvasinnovations.io">support@canvasinnovations.io</a> to exercise these rights. We may need to verify your identity before fulfilling requests.</p>
-  <h2>7. International Data Transfers</h2>
-  <p>If you access the Services from outside the country where our systems are hosted, your information may be transferred across borders subject to appropriate safeguards where required by law.</p>
-  <h2>8. Children’s Privacy</h2>
-  <p>The Services are not directed to children under 13 (or the minimum age in your jurisdiction). We do not knowingly collect information from children.</p>
-  <h2>9. Changes to this Policy</h2>
-  <p>We may update this Privacy Policy periodically. Material changes will be posted with an updated effective date.</p>
-  <h2>10. Contact</h2>
-  <p>Questions or requests regarding privacy: <a href="mailto:support@canvasinnovations.io">support@canvasinnovations.io</a></p>
-  <hr />
-  <p><em>Last updated: August 9, 2025</em></p>
-</body>
+    </section>
+
+    <section class="mb-8">
+      <h2>2. How We Use Information</h2>
+      <p class="mb-4">We process information to:</p>
+      <ul class="list-disc pl-6 space-y-2 mb-4">
+        <li>
+          Provide and maintain the Services (e.g., hosting, syncing, rendering
+          content);
+        </li>
+        <li>Authenticate users, secure accounts, and prevent abuse;</li>
+        <li>Communicate with you (service notices, security alerts, support);</li>
+        <li>Analyze usage to improve reliability and features;</li>
+        <li>Comply with legal obligations.</li>
+      </ul>
+    </section>
+
+    <section class="mb-8">
+      <h2>3. Sharing of Information</h2>
+      <p class="mb-4">
+        We do <strong>not</strong> sell your personal information. We may share
+        limited data with:
+      </p>
+      <ul class="list-disc pl-6 space-y-2 mb-4">
+        <li>
+          <strong>Service Providers:</strong> Hosting, database, analytics,
+          email, and customer support vendors bound by contracts to use data
+          solely to provide services to Stratella;
+        </li>
+        <li>
+          <strong>Legal/Compliance:</strong> Where required by law or to protect
+          rights, property, or safety;
+        </li>
+        <li>
+          <strong>Business Transfers:</strong> If we engage in a merger,
+          acquisition, or asset sale, your information may be transferred with
+          appropriate safeguards.
+        </li>
+      </ul>
+    </section>
+
+    <section class="mb-8">
+      <h2>4. Data Retention, Export, and Deletion</h2>
+      <ul class="list-disc pl-6 space-y-2 mb-4">
+        <li>
+          <strong>Retention:</strong> We retain personal data while your account
+          is active or as needed to provide the Services.
+        </li>
+        <li>
+          <strong>Export:</strong> You can export Your Content (where features
+          exist) or contact
+          <a href="mailto:support@canvasinnovations.io"
+            >support@canvasinnovations.io</a
+          >
+          for reasonable export assistance.
+        </li>
+        <li>
+          <strong>Deletion:</strong> You may delete Your Content and/or request
+          account deletion at any time via in‑app controls (if available) or
+          email
+          <a href="mailto:support@canvasinnovations.io"
+            >support@canvasinnovations.io</a
+          >.
+          <ul class="list-disc pl-6 space-y-2 mt-2">
+            <li>
+              Upon verified request, we delete personal data from active systems
+              within <strong>30 days</strong>; residual copies may remain in
+              encrypted backups or logs for a limited period (typically
+              <strong>up to 90 days</strong>) and will be purged on their normal
+              cycles.
+            </li>
+            <li>
+              We may retain information as required by law, to resolve disputes,
+              or enforce agreements.
+            </li>
+            <li>
+              We will instruct our service providers to delete corresponding
+              data they process for Stratella, where applicable.
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </section>
+
+    <section class="mb-8">
+      <h2>5. Security</h2>
+      <p class="mb-4">
+        We implement administrative, technical, and physical safeguards designed
+        to protect personal data. No method of transmission or storage is 100%
+        secure.
+      </p>
+    </section>
+
+    <section class="mb-8">
+      <h2>6. Your Rights</h2>
+      <p class="mb-4">
+        Depending on your location, you may have rights to access, correct,
+        delete, object to processing, or obtain a copy of your data. Contact
+        <a href="mailto:support@canvasinnovations.io"
+          >support@canvasinnovations.io</a
+        >
+        to exercise these rights. We may need to verify your identity before
+        fulfilling requests.
+      </p>
+    </section>
+
+    <section class="mb-8">
+      <h2>7. International Data Transfers</h2>
+      <p class="mb-4">
+        If you access the Services from outside the country where our systems
+        are hosted, your information may be transferred across borders subject
+        to appropriate safeguards where required by law.
+      </p>
+    </section>
+
+    <section class="mb-8">
+      <h2>8. Children’s Privacy</h2>
+      <p class="mb-4">
+        The Services are not directed to children under 13 (or the minimum age
+        in your jurisdiction). We do not knowingly collect information from
+        children.
+      </p>
+    </section>
+
+    <section class="mb-8">
+      <h2>9. Changes to this Policy</h2>
+      <p class="mb-4">
+        We may update this Privacy Policy periodically. Material changes will be
+        posted with an updated effective date.
+      </p>
+    </section>
+
+    <section class="mb-8">
+      <h2>10. Contact</h2>
+      <p class="mb-4">
+        Questions or requests regarding privacy:
+        <a href="mailto:support@canvasinnovations.io"
+          >support@canvasinnovations.io</a
+        >
+      </p>
+    </section>
+
+    <hr class="my-6" />
+
+    <p class="mb-4"><em>Last updated: August 9, 2025</em></p>
+  </body>
 </html>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -7,5 +7,10 @@ export default async function PrivacyPage() {
   const filePath = path.join(process.cwd(), 'public', 'legal', 'privacy.html')
   const html = await readFile(filePath, 'utf8')
   const body = html.match(/<body>([\s\S]*?)<\/body>/i)?.[1] ?? html
-  return <article dangerouslySetInnerHTML={{ __html: body }} />
+  return (
+    <article
+      className="prose mx-auto p-4"
+      dangerouslySetInnerHTML={{ __html: body }}
+    />
+  )
 }


### PR DESCRIPTION
## Summary
- refine privacy policy HTML with sectioned layout, consistent spacing, and list styles
- render privacy policy with prose-styled `<article>` container

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables required)*
- `npm run typecheck` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68c44f18d11c832792ecc728b8cc5901