### PR TITLE
feat: add about page and navigation links

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next'
+import { Heart, Users } from 'lucide-react'
+
+export const metadata: Metadata = {
+  title: 'About Stratella',
+  description: 'Learn about Stratella\'s mission, team, and values.'
+}
+
+export default function AboutPage() {
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-16 space-y-16">
+      <section className="text-center space-y-4">
+        <h1 className="text-4xl font-bold tracking-tight">About Stratella</h1>
+        <p className="text-lg text-muted-foreground">
+          Stratella helps teams stay focused and organized so they can do their best work.
+        </p>
+      </section>
+      <section className="grid gap-12 md:grid-cols-2">
+        <div className="flex flex-col items-center text-center space-y-3">
+          <Users className="h-10 w-10 text-primary" />
+          <h2 className="text-xl font-semibold">Our Team</h2>
+          <p className="text-muted-foreground">
+            We are a small group of builders dedicated to crafting tools that empower people.
+          </p>
+        </div>
+        <div className="flex flex-col items-center text-center space-y-3">
+          <Heart className="h-10 w-10 text-primary" />
+          <h2 className="text-xl font-semibold">Our Values</h2>
+          <p className="text-muted-foreground">
+            Openness, empathy, and a passion for helping others guide everything we do.
+          </p>
+        </div>
+      </section>
+    </main>
+  )
+}
+

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -16,6 +16,12 @@ export default function Footer() {
               GitHub
             </Link>
             <Link
+              href="/about"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              About
+            </Link>
+            <Link
               href="/privacy"
               target="_blank"
               rel="noopener noreferrer"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -88,6 +88,12 @@ export default function Header() {
                 </button>
                 <Separator className="my-2" />
                 <Link
+                  href="/about"
+                  className="rounded px-3 py-2 hover:bg-accent hover:text-accent-foreground"
+                >
+                  About
+                </Link>
+                <Link
                   href="/terms"
                   className="rounded px-3 py-2 hover:bg-accent hover:text-accent-foreground"
                 >
@@ -102,7 +108,12 @@ export default function Header() {
               </nav>
             </SheetContent>
           </Sheet>
-
+          <Link
+            href="/about"
+            className="hidden md:block rounded px-3 py-2 hover:bg-accent hover:text-accent-foreground"
+          >
+            About
+          </Link>
           <UserMenu />
         </div>
       </div>

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -15,8 +15,12 @@ vi.mock('next/link', () => ({
 import Footer from '../Footer'
 
 describe('Footer', () => {
-  it('renders legal links with target="_blank"', () => {
+  it('renders footer links', () => {
     const { getByRole } = render(<Footer />)
+
+    const about = getByRole('link', { name: 'About' }) as HTMLAnchorElement
+    expect(about.getAttribute('href')).toBe('/about')
+    expect(about.getAttribute('target')).toBeNull()
 
     const privacy = getByRole('link', { name: 'Privacy Policy' }) as HTMLAnchorElement
     expect(privacy.getAttribute('href')).toBe('/privacy')


### PR DESCRIPTION
## Summary
- add dedicated About page highlighting mission and values
- include About link in header and footer navigation
- test footer links including About

## Testing
- `npm run lint`
- `npm test`
- `NEXT_PUBLIC_SUPABASE_URL='http://localhost' NEXT_PUBLIC_SUPABASE_ANON_KEY='test' npm run build`
- `npm run typecheck` *(fails: Missing script 'typecheck')*

------
https://chatgpt.com/codex/tasks/task_e_68c455d5326883279aa743b54c499494