### PR TITLE
Add Why Stratella marketing page and navigation links

### DIFF
--- a/src/app/why-stratella/page.tsx
+++ b/src/app/why-stratella/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { FileText, CheckCircle, Globe } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+export const metadata: Metadata = {
+  title: 'Why Stratella | Remote Product Team Collaboration',
+  description:
+    'Discover how Stratella keeps distributed product teams collaborating securely and shipping faster.',
+}
+
+export default function WhyStratellaPage() {
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-16 space-y-24">
+      <section className="space-y-6 text-center">
+        <h1 className="text-4xl font-bold tracking-tight">Why Stratella</h1>
+        <p className="text-lg text-muted-foreground">
+          From brainstorm to backlog, Stratella keeps your remote product team aligned.
+        </p>
+        <div className="flex justify-center gap-4">
+          <Button asChild>
+            <Link href="/login">Get Started</Link>
+          </Button>
+          <Button asChild variant="outline">
+            <Link href="/about">Learn More</Link>
+          </Button>
+        </div>
+      </section>
+      <section className="grid gap-12 md:grid-cols-3">
+        <div className="flex flex-col items-center text-center space-y-3">
+          <FileText className="h-10 w-10 text-primary" />
+          <h2 className="text-xl font-semibold">Collaborative Specs</h2>
+          <p className="text-muted-foreground">
+            Keep ideas, decisions, and docs in sync so everyone builds from the same page.
+          </p>
+        </div>
+        <div className="flex flex-col items-center text-center space-y-3">
+          <CheckCircle className="h-10 w-10 text-primary" />
+          <h2 className="text-xl font-semibold">Enterprise Security</h2>
+          <p className="text-muted-foreground">
+            Granular permissions and audit trails safeguard your roadmap and customer data.
+          </p>
+        </div>
+        <div className="flex flex-col items-center text-center space-y-3">
+          <Globe className="h-10 w-10 text-primary" />
+          <h2 className="text-xl font-semibold">Built for Speed</h2>
+          <p className="text-muted-foreground">
+            Real-time updates keep globally distributed teams moving quickly from idea to release.
+          </p>
+        </div>
+      </section>
+    </main>
+  )
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -22,6 +22,12 @@ export default function Footer() {
               About
             </Link>
             <Link
+              href="/why-stratella"
+              className="text-sm text-muted-foreground hover:text-foreground transition-colors rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Why Stratella
+            </Link>
+            <Link
               href="/privacy"
               target="_blank"
               rel="noopener noreferrer"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -88,6 +88,12 @@ export default function Header() {
                 </button>
                 <Separator className="my-2" />
                 <Link
+                  href="/why-stratella"
+                  className="rounded px-3 py-2 hover:bg-accent hover:text-accent-foreground"
+                >
+                  Why Stratella
+                </Link>
+                <Link
                   href="/about"
                   className="rounded px-3 py-2 hover:bg-accent hover:text-accent-foreground"
                 >
@@ -108,6 +114,12 @@ export default function Header() {
               </nav>
             </SheetContent>
           </Sheet>
+          <Link
+            href="/why-stratella"
+            className="hidden md:block rounded px-3 py-2 hover:bg-accent hover:text-accent-foreground"
+          >
+            Why Stratella
+          </Link>
           <Link
             href="/about"
             className="hidden md:block rounded px-3 py-2 hover:bg-accent hover:text-accent-foreground"

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -22,6 +22,10 @@ describe('Footer', () => {
     expect(about.getAttribute('href')).toBe('/about')
     expect(about.getAttribute('target')).toBeNull()
 
+    const why = getByRole('link', { name: 'Why Stratella' }) as HTMLAnchorElement
+    expect(why.getAttribute('href')).toBe('/why-stratella')
+    expect(why.getAttribute('target')).toBeNull()
+
     const privacy = getByRole('link', { name: 'Privacy Policy' }) as HTMLAnchorElement
     expect(privacy.getAttribute('href')).toBe('/privacy')
     expect(privacy.getAttribute('target')).toBe('_blank')

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+;(globalThis as unknown as { React: typeof React }).React = React
+import { render } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('next/link', () => ({
+  default: ({ children, ...props }: { children: React.ReactNode } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a {...props}>{children}</a>
+  ),
+}))
+
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: ({ priority: _p, ...props }: React.ImgHTMLAttributes<HTMLImageElement>) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img {...props} alt={props.alt ?? ''} />
+  ),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+}))
+
+vi.mock('@/components/UserMenu', () => ({
+  __esModule: true,
+  default: () => <div />,
+}))
+
+vi.mock('@/lib/supabase-client', () => ({
+  supabaseClient: { auth: { signOut: vi.fn() } },
+}))
+
+import Header from '../Header'
+
+describe('Header', () => {
+  it('renders link to Why Stratella', () => {
+    const { getByRole } = render(<Header />)
+    const link = getByRole('link', { name: 'Why Stratella' }) as HTMLAnchorElement
+    expect(link.getAttribute('href')).toBe('/why-stratella')
+  })
+})


### PR DESCRIPTION
## Summary
- build marketing page explaining why Stratella and its benefits for remote product teams
- surface "Why Stratella" links in the header and footer
- add unit tests for header/footer links

## Testing
- `npm run lint`
- `npm test`
- `NEXT_PUBLIC_SUPABASE_URL="https://example.supabase.co" NEXT_PUBLIC_SUPABASE_ANON_KEY="anon" npm run build`
- `npm run typecheck` *(fails: Missing script "typecheck")*


------
https://chatgpt.com/codex/tasks/task_e_68c457984aa48327a067ae92382db000