### PR TITLE
feat: show login when signed out

### DIFF
--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,21 +19,11 @@ export default function UserMenu() {
   const [loading, setLoading] = useState(false);
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
 
-  useEffect(() => {
-    const {
-      data: { subscription },
-    } = supabaseClient.auth.onAuthStateChange((event) => {
-      if (event === "SIGNED_OUT") {
-        router.replace("/login");
-      }
-    });
-    return () => subscription.unsubscribe();
-  }, [router]);
-
   async function signOut() {
     setLoading(true);
     try {
       await supabaseClient.auth.signOut();
+      router.replace("/login");
     } finally {
       setLoading(false);
     }

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -1,16 +1,20 @@
 import React from 'react'
 ;(globalThis as unknown as { React: typeof React }).React = React
 import { render } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 vi.mock('next/link', () => ({
-  default: ({ children, ...props }: { children: React.ReactNode } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+  default: ({
+    children,
+    ...props
+  }: { children: React.ReactNode } & React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
     <a {...props}>{children}</a>
   ),
 }))
 
 vi.mock('next/image', () => ({
   __esModule: true,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   default: ({ priority: _p, ...props }: React.ImgHTMLAttributes<HTMLImageElement>) => (
     // eslint-disable-next-line @next/next/no-img-element
     <img {...props} alt={props.alt ?? ''} />
@@ -23,19 +27,44 @@ vi.mock('next/navigation', () => ({
 
 vi.mock('@/components/UserMenu', () => ({
   __esModule: true,
-  default: () => <div />,
+  default: () => <div>Account</div>,
 }))
 
+const { getSession, onAuthStateChange } = vi.hoisted(() => {
+  return {
+    getSession: vi.fn(),
+    onAuthStateChange: vi
+      .fn()
+      .mockReturnValue({ data: { subscription: { unsubscribe: vi.fn() } } }),
+  }
+})
+
 vi.mock('@/lib/supabase-client', () => ({
-  supabaseClient: { auth: { signOut: vi.fn() } },
+  supabaseClient: {
+    auth: { getSession, onAuthStateChange, signOut: vi.fn() },
+  },
 }))
 
 import Header from '../Header'
 
 describe('Header', () => {
-  it('renders link to Why Stratella', () => {
-    const { getByRole } = render(<Header />)
-    const link = getByRole('link', { name: 'Why Stratella' }) as HTMLAnchorElement
-    expect(link.getAttribute('href')).toBe('/why-stratella')
+  beforeEach(() => {
+    getSession.mockReset()
+  })
+
+  it('shows Login when no session', async () => {
+    getSession.mockResolvedValueOnce({ data: { session: null } })
+
+    const { findByText } = render(<Header />)
+    expect(await findByText('Login')).toBeTruthy()
+  })
+
+  it('shows Account when session exists', async () => {
+    getSession.mockResolvedValueOnce({ data: { session: {} } })
+
+    const { findByText, queryByText } = render(<Header />)
+    expect(await findByText('Account')).toBeTruthy()
+    expect(queryByText('Login')).toBeNull()
   })
 })
+


### PR DESCRIPTION
## Summary
- track Supabase session in header
- show Login button when signed out
- redirect after sign out and add tests

## Testing
- `npm run lint`
- `npm test`
- `npm run build`
- `npm run typecheck` *(fails: Missing script "typecheck")*

------
https://chatgpt.com/codex/tasks/task_e_68c45af98b688327a42eadebcc96b530