### PR TITLE
feat: add FAQ to support page

### DIFF
--- a/src/app/support/__tests__/SupportPage.test.tsx
+++ b/src/app/support/__tests__/SupportPage.test.tsx
@@ -3,8 +3,11 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import SupportPage from '../page'
 
-test('shows support email link', () => {
-  const { getByRole } = render(<SupportPage />)
+test('shows support email link and FAQ', () => {
+  const { getByRole, getByText } = render(<SupportPage />)
   const email = getByRole('link', { name: 'support@canvasinnovations.io' }) as HTMLAnchorElement
   expect(email.getAttribute('href')).toBe('mailto:support@canvasinnovations.io')
+  getByText('How do Tasks work?')
+  getByText('What can I do with Notes?')
+  getByText('How much does Stratella cost?')
 })

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -12,6 +12,32 @@ export default function SupportPage() {
         You can also browse our frequently asked questions to find common
         answers.
       </p>
+      <section className="mt-6">
+        <h2>FAQ</h2>
+        <dl className="space-y-4">
+          <div>
+            <dt>How do Tasks work?</dt>
+            <dd>
+              Tasks move through a simple workflow—create a task, track its
+              progress, and mark it complete when finished.
+            </dd>
+          </div>
+          <div>
+            <dt>What can I do with Notes?</dt>
+            <dd>
+              Use notes to brainstorm ideas and link them to related tasks for
+              easy reference.
+            </dd>
+          </div>
+          <div>
+            <dt>How much does Stratella cost?</dt>
+            <dd>
+              Stratella offers a free tier with additional features available on
+              paid plans.
+            </dd>
+          </div>
+        </dl>
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add FAQ section with Tasks, Notes, and pricing answers on Support page
- test Support page renders FAQ questions

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: either NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY env variables or supabaseUrl and supabaseKey are required)*
- `npm run typecheck` *(fails: Missing script: "typecheck" )*

------
https://chatgpt.com/codex/tasks/task_e_68c45de4476c832791cda155f3586ecb