### PR TITLE
Implement quick capture workflow

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css'
 import type { Metadata } from 'next'
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
+import { QuickCaptureProvider } from '@/components/quick-capture/QuickCaptureProvider'
 import { supabaseServer } from '@/lib/supabase-server'
 
 export const metadata: Metadata = {
@@ -25,9 +26,11 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="bg-[radial-gradient(60%_40%_at_50%_-10%,hsl(var(--primary)/0.08),transparent)] bg-background text-foreground">
-        <Header />
-        <main className="mx-auto max-w-5xl p-4">{children}</main>
-        {!session && <Footer />}
+        <QuickCaptureProvider>
+          <Header />
+          <main className="mx-auto max-w-5xl p-4">{children}</main>
+          {!session && <Footer />}
+        </QuickCaptureProvider>
       </body>
     </html>
   )

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -2,13 +2,12 @@ export const dynamic = 'force-dynamic'
 
 import { supabaseServer } from '@/lib/supabase-server'
 import { redirect } from 'next/navigation'
-import { createNote } from '@/app/actions'
-import { Button } from '@/components/ui/button'
 import { Note } from './NotesList'
 import { countOpenTasks } from '@/lib/taskparse'
 import { NavButton } from '@/components/NavButton'
 import { NotesClient } from './NotesClient'
 import { extractTitleFromHtml } from '@/lib/note'
+import { QuickCaptureButton } from '@/components/quick-capture/QuickCaptureButton'
 
 const EMPTY_HTML = '<h1></h1>'
 
@@ -34,18 +33,10 @@ export default async function NotesPage() {
         openTasks: countOpenTasks(n.body || '')
       }))
 
-  async function createBlankNote() {
-    'use server'
-    const id = await createNote()
-    redirect(`/notes/${id}`)
-  }
-
   return (
     <div className="space-y-6">
       <div className="flex gap-2">
-        <form action={createBlankNote}>
-          <Button type="submit">New</Button>
-        </form>
+        <QuickCaptureButton>Quick capture</QuickCaptureButton>
         <NavButton href="/tasks" variant="outline">
           View Tasks
         </NavButton>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,6 +10,7 @@ import { Separator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { supabaseClient } from "@/lib/supabase-client";
 import UserMenu from "@/components/UserMenu";
+import { QuickCaptureButton } from "@/components/quick-capture/QuickCaptureButton";
 
 export default function Header() {
   const router = useRouter();
@@ -151,6 +152,25 @@ export default function Header() {
           >
             About
           </Link>
+          {session && (
+            <>
+              <QuickCaptureButton
+                className="md:hidden"
+                size="icon"
+                variant="ghost"
+                showIcon
+                aria-label="Quick capture note"
+              >
+                <span className="sr-only">Quick capture</span>
+              </QuickCaptureButton>
+              <QuickCaptureButton
+                className="hidden md:inline-flex"
+                size="sm"
+              >
+                Quick capture
+              </QuickCaptureButton>
+            </>
+          )}
           {session ? (
             <UserMenu />
           ) : (

--- a/src/components/__tests__/Header.test.tsx
+++ b/src/components/__tests__/Header.test.tsx
@@ -46,6 +46,14 @@ vi.mock('@/lib/supabase-client', () => ({
 }))
 
 import Header from '../Header'
+import { QuickCaptureProvider } from '@/components/quick-capture/QuickCaptureProvider'
+
+const renderHeader = () =>
+  render(
+    <QuickCaptureProvider>
+      <Header />
+    </QuickCaptureProvider>,
+  )
 
 describe('Header', () => {
   beforeEach(() => {
@@ -55,14 +63,14 @@ describe('Header', () => {
   it('shows Login when no session', async () => {
     getSession.mockResolvedValueOnce({ data: { session: null } })
 
-    const { findByText } = render(<Header />)
+    const { findByText } = renderHeader()
     expect(await findByText('Login')).toBeTruthy()
   })
 
   it('shows Account when session exists', async () => {
     getSession.mockResolvedValueOnce({ data: { session: {} } })
 
-    const { findByText, queryByText } = render(<Header />)
+    const { findByText, queryByText } = renderHeader()
     expect(await findByText('Account')).toBeTruthy()
     expect(queryByText('Login')).toBeNull()
   })

--- a/src/components/editor/__tests__/autosaveOnSaved.test.tsx
+++ b/src/components/editor/__tests__/autosaveOnSaved.test.tsx
@@ -6,10 +6,19 @@ import { countOpenTasks } from "@/lib/taskparse";
 import "./setup";
 
 vi.mock("@/app/actions", () => ({
-  saveNoteInline: vi.fn((_: string, html: string) =>
+  saveNoteInline: vi.fn((id: string, html: string) =>
     Promise.resolve({
+      id,
       openTasks: countOpenTasks(html),
       updatedAt: "2024-01-02T00:00:00.000Z",
+    }),
+  ),
+  upsertNoteWithClientId: vi.fn((html: string) =>
+    Promise.resolve({
+      id: "note",
+      openTasks: countOpenTasks(html),
+      updatedAt: "2024-01-02T00:00:00.000Z",
+      title: "Untitled",
     }),
   ),
 }));
@@ -43,6 +52,7 @@ describe("InlineEditor autosave", () => {
 
     await waitFor(() => expect(onSaved).toHaveBeenCalled());
     expect(onSaved).toHaveBeenCalledWith({
+      id: "note",
       openTasks: 1,
       updatedAt: "2024-01-02T00:00:00.000Z",
     });

--- a/src/components/editor/__tests__/autosaveTitleBody.test.tsx
+++ b/src/components/editor/__tests__/autosaveTitleBody.test.tsx
@@ -4,8 +4,16 @@ import { describe, it, expect, vi } from "vitest";
 import "./setup";
 
 vi.mock("@/app/actions", () => ({
-  saveNoteInline: vi.fn(() =>
-    Promise.resolve({ openTasks: 0, updatedAt: "2024-01-02T00:00:00.000Z" })
+  saveNoteInline: vi.fn((id: string) =>
+    Promise.resolve({ id, openTasks: 0, updatedAt: "2024-01-02T00:00:00.000Z" })
+  ),
+  upsertNoteWithClientId: vi.fn(() =>
+    Promise.resolve({
+      id: "note",
+      openTasks: 0,
+      updatedAt: "2024-01-02T00:00:00.000Z",
+      title: "Untitled",
+    })
   ),
 }));
 

--- a/src/components/editor/__tests__/flushOnUnload.test.tsx
+++ b/src/components/editor/__tests__/flushOnUnload.test.tsx
@@ -6,7 +6,12 @@ import InlineEditor, { AUTOSAVE_THROTTLE_MS } from "../InlineEditor";
 import "./setup";
 
 vi.mock("@/app/actions", () => ({
-  saveNoteInline: vi.fn(() => Promise.resolve({ openTasks: 0, updatedAt: null })),
+  saveNoteInline: vi
+    .fn((id: string) => Promise.resolve({ id, openTasks: 0, updatedAt: null })),
+  upsertNoteWithClientId: vi
+    .fn(() =>
+      Promise.resolve({ id: "note", openTasks: 0, updatedAt: null, title: "" }),
+    ),
 }));
 
 vi.mock("../FloatingToolbar", () => ({
@@ -36,7 +41,7 @@ describe("InlineEditor unload", () => {
     fireEvent.input(editorEl);
 
     act(() => {
-      vi.advanceTimersByTime(AUTOSAVE_THROTTLE_MS - 1000);
+      vi.advanceTimersByTime(Math.max(AUTOSAVE_THROTTLE_MS - 100, 0));
     });
     act(() => {
       window.dispatchEvent(new Event("pagehide"));
@@ -57,7 +62,7 @@ describe("InlineEditor unload", () => {
     fireEvent.input(editorEl);
 
     act(() => {
-      vi.advanceTimersByTime(1000);
+      vi.advanceTimersByTime(Math.max(AUTOSAVE_THROTTLE_MS - 100, 0));
     });
     const ev = new Event("beforeunload", { cancelable: true });
     act(() => {

--- a/src/components/editor/__tests__/htmlParse.test.tsx
+++ b/src/components/editor/__tests__/htmlParse.test.tsx
@@ -6,8 +6,11 @@ import "./setup";
 
 vi.mock("@/app/actions", () => ({
   saveNoteInline: vi
-    .fn()
-    .mockResolvedValue({ openTasks: 0, updatedAt: null }),
+    .fn((id: string) =>
+      Promise.resolve({ id, openTasks: 0, updatedAt: null }),
+    ),
+  upsertNoteWithClientId: vi
+    .fn(() => Promise.resolve({ id: "note", openTasks: 0, updatedAt: null, title: "" })),
 }));
 
 vi.mock("../FloatingToolbar", () => ({

--- a/src/components/editor/__tests__/initialContent.test.tsx
+++ b/src/components/editor/__tests__/initialContent.test.tsx
@@ -6,8 +6,11 @@ import "./setup";
 
 vi.mock("@/app/actions", () => ({
   saveNoteInline: vi
-    .fn()
-    .mockResolvedValue({ openTasks: 0, updatedAt: null }),
+    .fn((id: string) =>
+      Promise.resolve({ id, openTasks: 0, updatedAt: null }),
+    ),
+  upsertNoteWithClientId: vi
+    .fn(() => Promise.resolve({ id: "note", openTasks: 0, updatedAt: null, title: "" })),
 }));
 
 vi.mock("../FloatingToolbar", () => ({

--- a/src/components/quick-capture/QuickCaptureButton.tsx
+++ b/src/components/quick-capture/QuickCaptureButton.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import * as React from "react";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useQuickCapture } from "./QuickCaptureProvider";
+
+type ButtonProps = React.ComponentProps<typeof Button>;
+
+interface QuickCaptureButtonProps extends ButtonProps {
+  showIcon?: boolean;
+}
+
+export function QuickCaptureButton({
+  children = "Quick capture",
+  showIcon = true,
+  onClick,
+  type,
+  ...props
+}: QuickCaptureButtonProps) {
+  const { openQuickCapture } = useQuickCapture();
+
+  const handleClick = React.useCallback<
+    NonNullable<ButtonProps["onClick"]>
+  >(
+    (event) => {
+      onClick?.(event);
+      if (event.defaultPrevented) return;
+      event.preventDefault();
+      openQuickCapture();
+    },
+    [onClick, openQuickCapture],
+  );
+
+  return (
+    <Button type={type ?? "button"} onClick={handleClick} {...props}>
+      {showIcon && <Plus className="size-4" aria-hidden />}
+      {children}
+    </Button>
+  );
+}
+

--- a/src/components/quick-capture/QuickCaptureProvider.tsx
+++ b/src/components/quick-capture/QuickCaptureProvider.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import InlineEditor from "@/components/editor/InlineEditor";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import type { SaveNoteInlineResult } from "@/app/actions";
+
+const EMPTY_HTML = "<h1></h1>";
+
+type QuickCaptureContextValue = {
+  openQuickCapture: () => void;
+  closeQuickCapture: () => void;
+};
+
+const QuickCaptureContext = React.createContext<QuickCaptureContextValue | null>(
+  null,
+);
+
+export function useQuickCapture() {
+  const context = React.useContext(QuickCaptureContext);
+  if (!context) {
+    throw new Error(
+      "useQuickCapture must be used within a QuickCaptureProvider",
+    );
+  }
+  return context;
+}
+
+export function QuickCaptureProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [editorKey, setEditorKey] = React.useState<string | null>(null);
+  const [modifierLabel, setModifierLabel] = React.useState("Ctrl");
+  const navigateOnSaveRef = React.useRef(false);
+
+  const closeQuickCapture = React.useCallback(() => {
+    setIsOpen(false);
+    setEditorKey(null);
+  }, []);
+
+  const openQuickCapture = React.useCallback(() => {
+    const generatedId =
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : Math.random().toString(36).slice(2);
+    setEditorKey(generatedId);
+    navigateOnSaveRef.current = false;
+    setIsOpen(true);
+  }, []);
+
+  const handleSaved = React.useCallback(
+    (result: SaveNoteInlineResult) => {
+      if (!navigateOnSaveRef.current) {
+        navigateOnSaveRef.current = true;
+        setIsOpen(false);
+        setEditorKey(null);
+        router.push(`/notes/${result.id}`);
+      }
+    },
+    [router],
+  );
+
+  React.useEffect(() => {
+    if (typeof navigator !== "undefined" && navigator.platform) {
+      setModifierLabel(navigator.platform.includes("Mac") ? "⌘" : "Ctrl");
+    }
+  }, []);
+
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      const isModifier = event.metaKey || event.ctrlKey;
+      if (isModifier && event.shiftKey && event.key.toLowerCase() === "n") {
+        const target = event.target as HTMLElement | null;
+        if (target) {
+          const tagName = target.tagName;
+          if (
+            target.isContentEditable ||
+            tagName === "INPUT" ||
+            tagName === "TEXTAREA"
+          ) {
+            return;
+          }
+        }
+        event.preventDefault();
+        openQuickCapture();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [openQuickCapture]);
+
+  const contextValue = React.useMemo(
+    () => ({ openQuickCapture, closeQuickCapture }),
+    [closeQuickCapture, openQuickCapture],
+  );
+
+  return (
+    <QuickCaptureContext.Provider value={contextValue}>
+      {children}
+      <Sheet
+        open={isOpen}
+        onOpenChange={(next) => {
+          if (!next) {
+            closeQuickCapture();
+          }
+        }}
+      >
+        <SheetContent side="right" className="sm:max-w-xl">
+          <SheetHeader className="pb-0">
+            <SheetTitle>Quick capture</SheetTitle>
+            <SheetDescription>
+              Start writing immediately. Your first save opens the full note.
+              Use ⇧ + {modifierLabel} + N anytime.
+            </SheetDescription>
+          </SheetHeader>
+          <div className="flex-1 overflow-hidden px-4 pb-6">
+            {editorKey ? (
+              <InlineEditor
+                key={editorKey}
+                html={EMPTY_HTML}
+                onSaved={handleSaved}
+              />
+            ) : null}
+          </div>
+        </SheetContent>
+      </Sheet>
+    </QuickCaptureContext.Provider>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a server action that upserts notes with client-provided IDs and reuse a serializer for title/task counts
- update the inline editor to generate client IDs, call the new upsert on first save, and throttle autosave sooner
- introduce a quick-capture provider, button, and header/notes integrations for global modal + shortcut access

## Testing
- npm run lint
- npm run test
- CI=1 npm run build *(fails: NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_68cd1d2210088327ae242e00753eb06a