### PR TITLE
Allow null filters in search API

### DIFF
--- a/src/app/api/search/__tests__/route.test.ts
+++ b/src/app/api/search/__tests__/route.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { POST } from '../route'
+import { supabaseServer } from '@/lib/supabase-server'
+
+vi.mock('@/lib/supabase-server', () => ({
+  supabaseServer: vi.fn(),
+}))
+
+describe('POST /api/search', () => {
+  let rpcMock: ReturnType<typeof vi.fn>
+  let getUserMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    rpcMock = vi.fn().mockResolvedValue({ data: [] })
+    getUserMock = vi
+      .fn()
+      .mockResolvedValue({ data: { user: { id: 'user-123' } }, error: null })
+
+    const supabase = {
+      auth: { getUser: getUserMock },
+      rpc: rpcMock,
+    }
+
+    vi
+      .mocked(supabaseServer)
+      .mockResolvedValue(supabase as Awaited<ReturnType<typeof supabaseServer>>)
+  })
+
+  test('returns results when optional filters are missing', async () => {
+    const request = new Request('http://localhost/api/search', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ scope: 'tasks' }),
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toEqual({ scope: 'tasks', page: 1, pageSize: 20, results: [] })
+
+    expect(rpcMock).toHaveBeenCalledWith('search_note_tasks', {
+      p_user_id: 'user-123',
+      p_query: null,
+      p_limit: 20,
+      p_offset: 0,
+      p_completion: null,
+      p_tag: null,
+      p_note_id: null,
+      p_due: null,
+      p_sort: 'text',
+    })
+  })
+})

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -5,7 +5,7 @@ import { supabaseServer } from '@/lib/supabase-server'
 export const dynamic = 'force-dynamic'
 
 const baseSchema = z.object({
-  query: z.string().optional(),
+  query: z.string().nullish(),
   page: z.number().int().min(1).optional(),
   pageSize: z.number().int().min(1).max(100).optional(),
 })
@@ -17,10 +17,10 @@ const notesSchema = baseSchema.extend({
 
 const tasksSchema = baseSchema.extend({
   scope: z.literal('tasks'),
-  completion: z.enum(['open', 'done']).optional(),
-  noteId: z.string().uuid().optional(),
-  tag: z.string().optional(),
-  due: z.string().optional(),
+  completion: z.enum(['open', 'done']).nullish(),
+  noteId: z.string().uuid().nullish(),
+  tag: z.string().nullish(),
+  due: z.string().nullish(),
   sort: z.enum(['due', 'text']).optional(),
 })
 


### PR DESCRIPTION
## Summary
- allow search API filters to accept nullish values in the Zod schema
- ensure the search route test covers requests without optional filters and validates Supabase arguments

## Testing
- npm run lint
- npm test
- CI=1 npm run build *(fails: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY are required during prerender)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f78313688327ba58cc025fd50ce5