### PR TITLE
Implement server-side search for notes and tasks

### DIFF
--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,0 +1,209 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { supabaseServer } from '@/lib/supabase-server'
+
+export const dynamic = 'force-dynamic'
+
+const baseSchema = z.object({
+  query: z.string().nullish(),
+  page: z.number().int().min(1).nullish(),
+  pageSize: z.number().int().min(1).max(100).nullish(),
+})
+
+const notesSchema = baseSchema.extend({
+  scope: z.literal('notes'),
+  sort: z.enum(['newest', 'oldest']).nullish(),
+})
+
+const tasksSchema = baseSchema.extend({
+  scope: z.literal('tasks'),
+  completion: z.enum(['open', 'done']).nullish(),
+  noteId: z.string().uuid().nullish(),
+  tag: z.string().nullish(),
+  due: z.string().nullish(),
+  sort: z.enum(['due', 'text']).nullish(),
+})
+
+const requestSchema = z.discriminatedUnion('scope', [notesSchema, tasksSchema])
+
+type NotesPayload = z.infer<typeof notesSchema>
+type TasksPayload = z.infer<typeof tasksSchema>
+
+type SearchResponse =
+  | {
+      scope: 'notes'
+      page: number
+      pageSize: number
+      results: {
+        id: string
+        title: string | null
+        updatedAt: string
+        openTasks: number
+        rank: number
+        highlightTitle: string | null
+        highlightBody: string | null
+      }[]
+    }
+  | {
+      scope: 'tasks'
+      page: number
+      pageSize: number
+      results: {
+        noteId: string
+        line: number
+        text: string
+        tags: string[]
+        due: string | null
+        status: string | null
+        isCompleted: boolean
+        noteTitle: string | null
+        noteUpdatedAt: string
+        rank: number
+        highlight: string | null
+      }[]
+    }
+
+function sanitizeQuery(value?: string | null) {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : null
+}
+
+export async function POST(req: Request) {
+  const json = await req.json().catch(() => null)
+  if (!json) {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const parsed = requestSchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid request', details: parsed.error.flatten() },
+      { status: 400 },
+    )
+  }
+
+  const payload = parsed.data
+  const supabase = await supabaseServer()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError) {
+    console.error(authError)
+    return NextResponse.json({ error: 'Authentication failed' }, { status: 401 })
+  }
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const page = payload.page ?? 1
+  const pageSize = payload.pageSize ?? 20
+  const offset = (page - 1) * pageSize
+
+  try {
+    if (payload.scope === 'notes') {
+      const response = await searchNotes(payload, {
+        supabase,
+        userId: user.id,
+        page,
+        pageSize,
+        offset,
+      })
+      return NextResponse.json(response satisfies SearchResponse)
+    }
+
+    const response = await searchTasks(payload, {
+      supabase,
+      userId: user.id,
+      page,
+      pageSize,
+      offset,
+    })
+    return NextResponse.json(response satisfies SearchResponse)
+  } catch (error) {
+    console.error(error)
+    return NextResponse.json({ error: 'Search failed' }, { status: 500 })
+  }
+}
+
+interface SearchContext {
+  supabase: Awaited<ReturnType<typeof supabaseServer>>
+  userId: string
+  page: number
+  pageSize: number
+  offset: number
+}
+
+async function searchNotes(payload: NotesPayload, ctx: SearchContext): Promise<SearchResponse> {
+  const queryText = sanitizeQuery(payload.query)
+  const { data, error } = await ctx.supabase.rpc('search_notes', {
+    p_user_id: ctx.userId,
+    p_query: queryText,
+    p_limit: ctx.pageSize,
+    p_offset: ctx.offset,
+    p_sort: payload.sort ?? 'newest',
+  })
+
+  if (error) {
+    throw error
+  }
+
+  const results = (data ?? []).map((row: Record<string, unknown>) => ({
+    id: row.id as string,
+    title: (row.title as string | null) ?? null,
+    updatedAt: row.updated_at as string,
+    openTasks: Number(row.open_tasks ?? 0),
+    rank: Number(row.rank ?? 0),
+    highlightTitle: (row.highlight_title as string | null) ?? null,
+    highlightBody: (row.highlight_body as string | null) ?? null,
+  }))
+
+  return {
+    scope: 'notes',
+    page: ctx.page,
+    pageSize: ctx.pageSize,
+    results,
+  }
+}
+
+async function searchTasks(payload: TasksPayload, ctx: SearchContext): Promise<SearchResponse> {
+  const queryText = sanitizeQuery(payload.query)
+  const { data, error } = await ctx.supabase.rpc('search_note_tasks', {
+    p_user_id: ctx.userId,
+    p_query: queryText,
+    p_limit: ctx.pageSize,
+    p_offset: ctx.offset,
+    p_completion: payload.completion ?? null,
+    p_tag: sanitizeQuery(payload.tag),
+    p_note_id: payload.noteId ?? null,
+    p_due: sanitizeQuery(payload.due),
+    p_sort: payload.sort ?? 'text',
+  })
+
+  if (error) {
+    throw error
+  }
+
+  const results = (data ?? []).map((row: Record<string, unknown>) => ({
+    noteId: row.note_id as string,
+    line: Number(row.line ?? 0),
+    text: row.text as string,
+    tags: (row.tags as string[]) ?? [],
+    due: (row.due as string | null) ?? null,
+    status: (row.status as string | null) ?? null,
+    isCompleted: Boolean(row.is_completed),
+    noteTitle: (row.note_title as string | null) ?? null,
+    noteUpdatedAt: row.note_updated_at as string,
+    rank: Number(row.rank ?? 0),
+    highlight: (row.highlight as string | null) ?? null,
+  }))
+
+  return {
+    scope: 'tasks',
+    page: ctx.page,
+    pageSize: ctx.pageSize,
+    results,
+  }
+}

--- a/src/app/notes/NotesClient.tsx
+++ b/src/app/notes/NotesClient.tsx
@@ -1,27 +1,100 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import ViewSelector from '@/components/ViewSelector'
 import FilterBar, { NoteFilters } from '@/components/notes/FilterBar'
 import { Filter } from 'lucide-react'
 import { NotesList, type Note } from './NotesList'
 
+type SearchState = {
+  loading: boolean
+  error: string | null
+}
+
 export function NotesClient({ notes }: { notes: Note[] }) {
   const [showFilters, setShowFilters] = useState(false)
   const [filters, setFilters] = useState<NoteFilters>({ sort: 'newest' })
+  const [results, setResults] = useState<Note[]>(notes)
+  const [{ loading, error }, setSearchState] = useState<SearchState>({ loading: false, error: null })
+  const lastRequest = useRef<number>(0)
 
-  const filtered = useMemo(() => {
-    let res = [...notes]
-    if (filters.search) {
-      const s = filters.search.toLowerCase()
-      res = res.filter(n => n.title.toLowerCase().includes(s))
+  useEffect(() => {
+    setResults(notes)
+    setSearchState({ loading: false, error: null })
+  }, [notes])
+
+  useEffect(() => {
+    const requestId = Date.now()
+    lastRequest.current = requestId
+
+    const controller = new AbortController()
+    const timeout = setTimeout(async () => {
+      setSearchState(prev => ({ ...prev, loading: true, error: null }))
+      try {
+        const res = await fetch('/api/search', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            scope: 'notes',
+            query: filters.search ?? null,
+            sort: filters.sort,
+            page: 1,
+            pageSize: 50,
+          }),
+          signal: controller.signal,
+        })
+
+        if (!res.ok) {
+          throw new Error(`Search failed with status ${res.status}`)
+        }
+
+        const data = (await res.json()) as {
+          results: Array<Partial<Note> & { updatedAt?: string }>
+        }
+
+        if (lastRequest.current === requestId) {
+          const mapped = (data.results ?? [])
+            .filter(result => Boolean(result.id))
+            .map(result => ({
+              id: result.id as string,
+              title: (result.title as string | undefined) ?? '',
+              updated_at: (result.updatedAt as string | undefined) ?? new Date().toISOString(),
+              openTasks: Number(result.openTasks ?? 0),
+              highlightTitle: (result.highlightTitle as string | null | undefined) ?? null,
+              highlightBody: (result.highlightBody as string | null | undefined) ?? null,
+              rank: Number(result.rank ?? 0),
+            }))
+          setResults(mapped)
+        }
+      } catch (err) {
+        if (controller.signal.aborted) {
+          return
+        }
+        console.error(err)
+        if (lastRequest.current === requestId) {
+          setSearchState({ loading: false, error: 'Unable to load notes. Please try again.' })
+        }
+        return
+      }
+
+      if (lastRequest.current === requestId) {
+        setSearchState({ loading: false, error: null })
+      }
+    }, filters.search ? 250 : 0)
+
+    return () => {
+      controller.abort()
+      clearTimeout(timeout)
     }
-    res.sort((a, b) => {
-      const diff = new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime()
-      return filters.sort === 'oldest' ? diff : -diff
-    })
-    return res
-  }, [notes, filters])
+  }, [filters])
+
+  const emptyMessage = useMemo(() => {
+    if (loading) return 'Loading notes…'
+    if (error) return error
+    return filters.search ? 'No matching notes found' : 'No notes available'
+  }, [loading, error, filters.search])
 
   return (
     <div className="space-y-3">
@@ -44,7 +117,18 @@ export function NotesClient({ notes }: { notes: Note[] }) {
         </button>
       </div>
       {showFilters && <FilterBar onChange={setFilters} />}
-      <NotesList notes={filtered} />
+      {error && results.length > 0 && (
+        <p className="text-sm text-destructive" role="alert">
+          {error}
+        </p>
+      )}
+      {results.length === 0 ? (
+        <p className="text-sm text-muted-foreground" aria-live="polite">
+          {emptyMessage}
+        </p>
+      ) : (
+        <NotesList notes={results} loading={loading} />
+      )}
     </div>
   )
 }

--- a/src/app/notes/NotesList.tsx
+++ b/src/app/notes/NotesList.tsx
@@ -3,16 +3,46 @@
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { Card, CardContent } from '@/components/ui/card'
+
 export type Note = {
   id: string
   title: string
   updated_at: string
   openTasks: number
+  highlightTitle?: string | null
+  highlightBody?: string | null
+  rank?: number
 }
 
 type View = 'card' | 'grid' | 'list'
 
-export function NotesList({ notes }: { notes: Note[] }) {
+interface NotesListProps {
+  notes: Note[]
+  loading?: boolean
+}
+
+function Highlight({
+  text,
+  fallback,
+  className,
+}: {
+  text?: string | null
+  fallback: string
+  className?: string
+}) {
+  if (text && text.trim()) {
+    return (
+      <span
+        className={className}
+        dangerouslySetInnerHTML={{ __html: text }}
+        suppressHydrationWarning
+      />
+    )
+  }
+  return <span className={className}>{fallback}</span>
+}
+
+export function NotesList({ notes, loading }: NotesListProps) {
   const params = useSearchParams()
   const view = (params.get('view') as View) ?? 'card'
 
@@ -22,33 +52,55 @@ export function NotesList({ notes }: { notes: Note[] }) {
       : 'grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3 auto-rows-fr'
 
   return view === 'list' ? (
-    <ul className="divide-y">
+    <ul className="divide-y" aria-busy={loading}>
       {notes.map(n => {
         const date = new Date(n.updated_at).toUTCString()
         return (
-          <li key={n.id}>
+          <li key={n.id} className="py-2">
             <Link
               href={`/notes/${n.id}`}
-              className="flex items-center justify-between py-2"
+              className="flex items-center justify-between gap-4"
             >
-              <span className="font-medium">{n.title || 'Untitled'}</span>
-              <span className="text-xs text-muted-foreground">
+              <Highlight
+                text={n.highlightTitle}
+                fallback={n.title || 'Untitled'}
+                className="font-medium"
+              />
+              <span className="text-xs text-muted-foreground whitespace-nowrap">
                 Updated {date} • {n.openTasks} open tasks
               </span>
             </Link>
+            {n.highlightBody && (
+              <p
+                className="mt-1 text-xs text-muted-foreground"
+                dangerouslySetInnerHTML={{ __html: n.highlightBody }}
+                suppressHydrationWarning
+              />
+            )}
           </li>
         )
       })}
     </ul>
   ) : (
-    <div className={gridClass}>
+    <div className={gridClass} aria-busy={loading}>
       {notes.map(n => {
         const date = new Date(n.updated_at).toUTCString()
         return (
           <Link key={n.id} href={`/notes/${n.id}`} className="block h-full">
             <Card className="h-full flex flex-col hover:bg-accent/30 transition">
-              <CardContent className="p-4 flex-1">
-                <div className="font-medium">{n.title || 'Untitled'}</div>
+              <CardContent className="p-4 flex-1 space-y-2">
+                <Highlight
+                  text={n.highlightTitle}
+                  fallback={n.title || 'Untitled'}
+                  className="font-medium"
+                />
+                {n.highlightBody && (
+                  <div
+                    className="text-xs text-muted-foreground line-clamp-3"
+                    dangerouslySetInnerHTML={{ __html: n.highlightBody }}
+                    suppressHydrationWarning
+                  />
+                )}
                 <div className="text-xs text-muted-foreground">
                   Updated {date} • {n.openTasks} open tasks
                 </div>

--- a/src/app/notes/__tests__/NotesClient.test.tsx
+++ b/src/app/notes/__tests__/NotesClient.test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 (globalThis as unknown as { React: typeof React }).React = React;
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 
 const replace = vi.fn();
@@ -18,26 +18,71 @@ const notes = [
   { id: "2", title: "Beta", updated_at: "2024-01-01T00:00:00Z", openTasks: 0 },
 ];
 
-test("filter bar toggles and filters notes", () => {
-  render(<NotesClient notes={notes} />);
+beforeEach(() => {
+  const okResponse = (payload: unknown) => ({ ok: true, json: async () => payload })
+
+  global.fetch = vi
+    .fn()
+    .mockResolvedValueOnce(okResponse({
+      results: notes.map(n => ({ ...n, updatedAt: n.updated_at })),
+    }))
+    .mockResolvedValueOnce(okResponse({
+      results: [notes[0]].map(n => ({ ...n, updatedAt: n.updated_at })),
+    }))
+    .mockResolvedValueOnce(okResponse({
+      results: notes.map(n => ({ ...n, updatedAt: n.updated_at })),
+    }))
+    .mockResolvedValueOnce(okResponse({
+      results: [...notes]
+        .reverse()
+        .map(n => ({ ...n, updatedAt: n.updated_at })),
+    })) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  // @ts-expect-error reset mocked fetch
+  delete global.fetch;
+});
+
+test("filter bar toggles and filters notes", async () => {
+  await act(async () => {
+    render(<NotesClient notes={notes} />);
+  });
 
   // Initially hidden
   expect(screen.queryByPlaceholderText("Search title…")).toBeNull();
 
   // Toggle filter bar
-  fireEvent.click(screen.getByLabelText("Toggle filters"));
+  await act(async () => {
+    fireEvent.click(screen.getByLabelText("Toggle filters"));
+  });
   const search = screen.getByPlaceholderText("Search title…");
   expect(search).toBeTruthy();
 
-  // Search filter
-  fireEvent.change(search, { target: { value: "Alpha" } });
-  expect(screen.getByText("Alpha")).toBeTruthy();
-  expect(screen.queryByText("Beta")).toBeNull();
+  // Search filter triggers server fetch
+  await act(async () => {
+    fireEvent.change(search, { target: { value: "Alpha" } });
+  });
+  await waitFor(() => {
+    expect((global.fetch as unknown as vi.Mock).mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+  await waitFor(() => {
+    expect(screen.getByText("Alpha")).toBeTruthy();
+    expect(screen.queryByText("Beta")).toBeNull();
+  });
 
-  // Sort oldest
-  fireEvent.change(search, { target: { value: "" } });
+  // Clear search and sort oldest
+  await act(async () => {
+    fireEvent.change(search, { target: { value: "" } });
+  });
   const select = screen.getByLabelText("Sort notes") as HTMLSelectElement;
-  fireEvent.change(select, { target: { value: "oldest" } });
-  const links = screen.getAllByRole("link");
-  expect(links[0].textContent).toContain("Beta");
+  await act(async () => {
+    fireEvent.change(select, { target: { value: "oldest" } });
+  });
+  await waitFor(() => {
+    const calls = (global.fetch as unknown as vi.Mock).mock.calls;
+    const [, options] = calls[calls.length - 1];
+    expect(JSON.parse(options.body as string)).toMatchObject({ scope: "notes", sort: "oldest" });
+  });
 });

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -13,25 +13,29 @@ const EMPTY_HTML = '<h1></h1>'
 
 export default async function NotesPage() {
   const supabase = await supabaseServer()
-  const { data: { user } } = await supabase.auth.getUser()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
   if (!user) redirect('/login')
 
-    const { data: notes } = await supabase
-      .from('notes')
-      .select('id,updated_at,body')
-      .order('updated_at', { ascending: false })
+  const { data: notes } = await supabase
+    .from('notes')
+    .select('id,updated_at,body')
+    .order('updated_at', { ascending: false })
 
   const enriched: Note[] = (notes ?? [])
     .filter(n => {
       const body = (n.body ?? '').trim()
       return body !== '' && body !== EMPTY_HTML
     })
-      .map(n => ({
-        id: n.id,
-        title: extractTitleFromHtml(n.body),
-        updated_at: n.updated_at,
-        openTasks: countOpenTasks(n.body || '')
-      }))
+    .map(n => ({
+      id: n.id,
+      title: extractTitleFromHtml(n.body),
+      updated_at: n.updated_at,
+      openTasks: countOpenTasks(n.body || ''),
+      highlightTitle: null,
+      highlightBody: null,
+    }))
 
   return (
     <div className="space-y-6">

--- a/src/app/tasks/TasksClient.tsx
+++ b/src/app/tasks/TasksClient.tsx
@@ -1,0 +1,257 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import TasksFilters from '@/components/tasks/TasksFilters'
+import ViewSelector from '@/components/ViewSelector'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import TaskRow from '@/components/tasks/TaskRow'
+import { useSearchParams } from 'next/navigation'
+import { NavButton } from '@/components/NavButton'
+
+type NoteOption = { id: string; title: string }
+
+type FilterState = {
+  completion?: string
+  tag?: string
+  due?: string
+  sort?: string
+  note?: string
+  search?: string
+}
+
+type TaskResult = {
+  noteId: string
+  line: number
+  text: string
+  tags: string[]
+  due: string | null
+  status: string | null
+  isCompleted: boolean
+  noteTitle: string | null
+  noteUpdatedAt: string
+  highlight: string | null
+  rank?: number
+}
+
+interface TasksClientProps {
+  notes: NoteOption[]
+  tags: string[]
+  initialFilters: FilterState
+  initialTasks: TaskResult[]
+  initialError?: string | null
+}
+
+type SearchState = {
+  loading: boolean
+  error: string | null
+}
+
+export function TasksClient({ notes, tags, initialFilters, initialTasks, initialError }: TasksClientProps) {
+  const [filters, setFilters] = useState<FilterState>(initialFilters)
+  const [tasks, setTasks] = useState<TaskResult[]>(initialTasks)
+  const [{ loading, error }, setSearchState] = useState<SearchState>({
+    loading: false,
+    error: initialError ?? null,
+  })
+  const lastRequest = useRef<number>(0)
+  const searchParams = useSearchParams()
+
+  useEffect(() => {
+    setFilters(initialFilters)
+    setTasks(initialTasks)
+    setSearchState({ loading: false, error: initialError ?? null })
+  }, [initialFilters, initialTasks, initialError])
+
+  useEffect(() => {
+    const requestId = Date.now()
+    lastRequest.current = requestId
+    const controller = new AbortController()
+    const timeout = setTimeout(async () => {
+      setSearchState(prev => ({ ...prev, loading: true, error: null }))
+      try {
+        const res = await fetch('/api/search', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            scope: 'tasks',
+            query: filters.search ?? null,
+            completion: filters.completion ?? null,
+            noteId: filters.note ?? null,
+            tag: filters.tag ?? null,
+            due: filters.due ?? null,
+            sort: filters.sort ?? 'text',
+            page: 1,
+            pageSize: 200,
+          }),
+          signal: controller.signal,
+        })
+
+        if (!res.ok) {
+          throw new Error(`Task search failed with status ${res.status}`)
+        }
+
+        const data = (await res.json()) as {
+          results: Array<Partial<TaskResult>>
+        }
+
+        if (lastRequest.current === requestId) {
+          const mapped = (data.results ?? [])
+            .filter(result => Boolean(result.noteId))
+            .map(result => ({
+              noteId: result.noteId as string,
+              line: Number.isFinite(Number(result.line)) ? Number(result.line) : 0,
+              text: (result.text as string | undefined) ?? '',
+              tags: (result.tags as string[] | undefined) ?? [],
+              due: (result.due as string | null | undefined) ?? null,
+              status: (result.status as string | null | undefined) ?? null,
+              isCompleted: Boolean(result.isCompleted),
+              noteTitle: (result.noteTitle as string | null | undefined) ?? null,
+              noteUpdatedAt: (result.noteUpdatedAt as string | undefined) ?? new Date().toISOString(),
+              highlight: (result.highlight as string | null | undefined) ?? null,
+              rank: Number(result.rank ?? 0),
+            }))
+          setTasks(mapped)
+        }
+      } catch (err) {
+        if (controller.signal.aborted) {
+          return
+        }
+        console.error(err)
+        if (lastRequest.current === requestId) {
+          setSearchState({ loading: false, error: 'Unable to load tasks. Please try again.' })
+        }
+        return
+      }
+
+      if (lastRequest.current === requestId) {
+        setSearchState({ loading: false, error: null })
+      }
+    }, filters.search ? 250 : 0)
+
+    return () => {
+      controller.abort()
+      clearTimeout(timeout)
+    }
+  }, [filters])
+
+  const groups = useMemo(() => {
+    const collection = new Map<string, { id: string; title: string; updatedAt: string; tasks: TaskResult[] }>()
+    tasks.forEach(task => {
+      const title =
+        task.noteTitle && task.noteTitle.trim()
+          ? task.noteTitle
+          : notes.find(n => n.id === task.noteId)?.title || 'Untitled'
+      if (!collection.has(task.noteId)) {
+        collection.set(task.noteId, { id: task.noteId, title, updatedAt: task.noteUpdatedAt, tasks: [] })
+      }
+      collection.get(task.noteId)!.tasks.push(task)
+    })
+    return Array.from(collection.values()).sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+  }, [tasks, notes])
+
+  const view = useMemo(() => {
+    const value = searchParams.get('view')
+    return value === 'card' ? 'card' : 'list'
+  }, [searchParams])
+
+  const emptyMessage = useMemo(() => {
+    if (loading) return 'Loading tasks…'
+    if (error) return error
+    if (filters.completion === 'done') return 'No closed tasks'
+    if (filters.search) return 'No tasks matched your search'
+    return 'No tasks found'
+  }, [loading, error, filters.completion, filters.search])
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Task List</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <TasksFilters
+          notes={notes}
+          tags={tags}
+          onFiltersChange={next => setFilters({ ...next })}
+        >
+          <ViewSelector
+            defaultValue="list"
+            options={[
+              { value: 'list', label: 'List', icon: 'list' },
+              { value: 'card', label: 'Card', icon: 'card' },
+            ]}
+          />
+        </TasksFilters>
+        {error && groups.length > 0 && (
+          <p className="text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+        {groups.length === 0 ? (
+          <p className="text-muted-foreground text-sm" aria-live="polite">
+            {emptyMessage}
+          </p>
+        ) : view === 'card' ? (
+          <div className="grid gap-4 sm:grid-cols-2" aria-busy={loading}>
+            {groups.map(group => (
+              <Card key={group.id} className="hover:shadow-sm transition w-full">
+                <CardHeader>
+                  <CardTitle>
+                    <NavButton
+                      href={`/notes/${group.id}`}
+                      variant="link"
+                      className="p-0 h-auto font-medium underline"
+                    >
+                      <span className="truncate block max-w-[12rem]">
+                        {group.title}
+                      </span>
+                    </NavButton>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <ul className="space-y-2">
+                    {group.tasks.map(task => (
+                      <TaskRow
+                        key={`${group.id}-${task.line}`}
+                        task={{ title: task.text, done: task.isCompleted, due: task.due ?? undefined, highlight: task.highlight ?? undefined }}
+                        noteId={group.id}
+                        line={task.line}
+                      />
+                    ))}
+                  </ul>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-6" aria-busy={loading}>
+            {groups.map(group => (
+              <div key={group.id}>
+                <NavButton
+                  href={`/notes/${group.id}`}
+                  variant="link"
+                  className="p-0 h-auto font-medium underline"
+                >
+                  {group.title}
+                </NavButton>
+                <ul className="mt-2 space-y-2">
+                  {group.tasks.map(task => (
+                    <TaskRow
+                      key={`${group.id}-${task.line}`}
+                      task={{ title: task.text, done: task.isCompleted, due: task.due ?? undefined, highlight: task.highlight ?? undefined }}
+                      noteId={group.id}
+                      line={task.line}
+                    />
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+export default TasksClient

--- a/src/app/tasks/__tests__/TasksPage.test.tsx
+++ b/src/app/tasks/__tests__/TasksPage.test.tsx
@@ -19,37 +19,108 @@ vi.mock("@/app/actions", () => ({
   setTaskDueFromNote: vi.fn(),
 }));
 
-  const notes = [
-    {
-      id: "n1",
-      updated_at: "2024-01-01T00:00:00Z",
-      body: '<h1>Note A</h1><ul><li data-type="taskItem" data-checked="false"><div>Task 1</div></li></ul>',
-    },
-    {
-      id: "n2",
-      updated_at: "2024-01-02T00:00:00Z",
-      body: '<h1>Note B</h1><ul><li data-type="taskItem" data-checked="false"><div>Task 2</div></li></ul>',
-    },
-  ];
+const notes = [
+  {
+    id: "n1",
+    title: "Note A",
+    updated_at: "2024-01-01T00:00:00Z",
+    body: '<h1>Note A</h1><ul><li data-type="taskItem" data-checked="false"><div>Task 1</div></li></ul>',
+  },
+  {
+    id: "n2",
+    title: "Note B",
+    updated_at: "2024-01-02T00:00:00Z",
+    body: '<h1>Note B</h1><ul><li data-type="taskItem" data-checked="false"><div>Task 2</div></li></ul>',
+  },
+];
+
+const taskRows = [
+  {
+    note_id: "n1",
+    line: 0,
+    text: "Task 1",
+    tags: [],
+    due: null,
+    status: null,
+    is_completed: false,
+    note_title: "Note A",
+    note_updated_at: "2024-01-01T00:00:00Z",
+    highlight: null,
+    rank: 0,
+  },
+  {
+    note_id: "n2",
+    line: 0,
+    text: "Task 2",
+    tags: [],
+    due: null,
+    status: null,
+    is_completed: false,
+    note_title: "Note B",
+    note_updated_at: "2024-01-02T00:00:00Z",
+    highlight: null,
+    rank: 0,
+  },
+];
+
+const supabaseMock = {
+  auth: { getUser: async () => ({ data: { user: { id: "user-1" } } }) },
+  from: (table: string) => {
+    if (table === "notes") {
+      return {
+        select: () => ({
+          order: () => Promise.resolve({ data: notes }),
+        }),
+      };
+    }
+    if (table === "note_tasks") {
+      return {
+        select: () => Promise.resolve({ data: [{ tags: [] }] }),
+      };
+    }
+    return {
+      select: () => Promise.resolve({ data: [] }),
+    };
+  },
+  rpc: vi.fn(),
+};
 
 vi.mock("@/lib/supabase-server", () => ({
-  supabaseServer: async () => ({
-    auth: { getUser: async () => ({ data: { user: {} } }) },
-    from: () => ({
-      select: () => ({
-        order: () => Promise.resolve({ data: notes }),
-      }),
-    }),
-  }),
+  supabaseServer: async () => supabaseMock,
 }));
+
+beforeEach(() => {
+  (supabaseMock.rpc as vi.Mock).mockReset();
+  (supabaseMock.rpc as vi.Mock).mockImplementation(async (fn: string) => {
+    if (fn === "search_note_tasks") {
+      return { data: taskRows, error: null };
+    }
+    return { data: [], error: null };
+  });
+  (global.fetch as unknown as vi.Mock | undefined)?.mockRestore?.();
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ results: taskRows.map(row => ({
+      noteId: row.note_id,
+      line: row.line,
+      text: row.text,
+      tags: row.tags,
+      due: row.due,
+      status: row.status,
+      isCompleted: row.is_completed,
+      noteTitle: row.note_title,
+      noteUpdatedAt: row.note_updated_at,
+      highlight: row.highlight,
+      rank: row.rank,
+    })) }),
+  }) as unknown as typeof fetch;
+});
 
 import TasksPage from "../page";
 
 test("renders list view by default", async () => {
   params.set("view", "list");
-  const { container } = render(
-    await TasksPage({ searchParams: Promise.resolve({ view: "list" }) })
-  );
+  const { container } = render(await TasksPage({ searchParams: Promise.resolve({ view: "list" }) }));
   expect(container.querySelectorAll('[data-slot="card"]').length).toBe(1);
   expect(screen.getByText("Note A")).toBeTruthy();
   expect(screen.getByText("Note B")).toBeTruthy();
@@ -57,9 +128,15 @@ test("renders list view by default", async () => {
 
 test("renders card view when view=card", async () => {
   params.set("view", "card");
-  const { container } = render(
-    await TasksPage({ searchParams: Promise.resolve({ view: "card" }) })
-  );
+  const { container } = render(await TasksPage({ searchParams: Promise.resolve({ view: "card" }) }));
   // outer card + two note group cards
   expect(container.querySelectorAll('[data-slot="card"]').length).toBe(3);
+});
+
+test("shows an error message when the RPC fails", async () => {
+  (supabaseMock.rpc as vi.Mock).mockResolvedValueOnce({ data: null, error: new Error("rpc failed") });
+  params.delete("view");
+  const { container } = render(await TasksPage({ searchParams: Promise.resolve({}) }));
+  expect(container.querySelectorAll('[data-slot="card"]').length).toBe(1);
+  expect(screen.getByText("Unable to load tasks. Please try again.")).toBeTruthy();
 });

--- a/src/components/tasks/TaskRow.tsx
+++ b/src/components/tasks/TaskRow.tsx
@@ -10,6 +10,7 @@ interface Task {
   title: string
   done: boolean
   due?: string
+  highlight?: string | null
 }
 
 interface TaskRowProps {
@@ -46,7 +47,14 @@ export default function TaskRow({ task, noteId, line }: TaskRowProps) {
         aria-label={task.done ? 'Mark task incomplete' : 'Mark task complete'}
       />
       <span className={cn('flex-1', task.done && 'line-through text-muted-foreground')}>
-        {task.title}
+        {task.highlight ? (
+          <span
+            dangerouslySetInnerHTML={{ __html: task.highlight }}
+            suppressHydrationWarning
+          />
+        ) : (
+          task.title
+        )}
       </span>
       <DateFilterTrigger
         value={task.due}

--- a/src/components/tasks/TasksFilterBar.tsx
+++ b/src/components/tasks/TasksFilterBar.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation'
 import DateFilterTrigger from './DateFilterTrigger'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
+import { Input } from '@/components/ui/input'
 import type { TaskFilters } from '@/lib/taskparse'
 import { track } from '@/lib/analytics'
 
@@ -15,6 +16,7 @@ interface NoteOption {
 
 interface FilterState extends TaskFilters {
   note?: string
+  search?: string
 }
 
 interface TasksFilterBarProps {
@@ -32,6 +34,7 @@ export default function TasksFilterBar({ notes, tags, onChange, onApply }: Tasks
     tag: searchParams.get('tag') ?? undefined,
     due: searchParams.get('due') ?? undefined,
     sort: searchParams.get('sort') ?? undefined,
+    search: searchParams.get('search') ?? undefined,
   })
 
   useEffect(() => {
@@ -45,6 +48,7 @@ export default function TasksFilterBar({ notes, tags, onChange, onApply }: Tasks
       tag: searchParams.get('tag') ?? undefined,
       due: searchParams.get('due') ?? undefined,
       sort: searchParams.get('sort') ?? undefined,
+      search: searchParams.get('search') ?? undefined,
     })
   }, [searchParams])
 
@@ -75,10 +79,18 @@ export default function TasksFilterBar({ notes, tags, onChange, onApply }: Tasks
   if (filters.tag) pills.push({ key: 'tag', label: `#${filters.tag}` })
   if (filters.due) pills.push({ key: 'due', label: filters.due })
   if (filters.sort) pills.push({ key: 'sort', label: `Sort ${filters.sort}` })
+  if (filters.search) pills.push({ key: 'search', label: `“${filters.search}”` })
 
   return (
     <div className="flex flex-wrap items-center gap-2">
       <div className="flex flex-wrap gap-2">
+        <Input
+          value={filters.search ?? ''}
+          onChange={e => update({ search: e.target.value || undefined })}
+          placeholder="Search tasks…"
+          className="h-9 w-48"
+          aria-label="Search tasks"
+        />
         <select
           value={filters.completion ?? ''}
           onChange={e => update({ completion: e.target.value || undefined })}

--- a/src/components/tasks/TasksFilters.tsx
+++ b/src/components/tasks/TasksFilters.tsx
@@ -12,13 +12,15 @@ interface TasksFiltersProps {
   notes: NoteOption[]
   tags: string[]
   children?: ReactNode
+  onFiltersChange?: (filters: FilterState) => void
 }
 
 interface FilterState extends TaskFilters {
   note?: string
+  search?: string
 }
 
-export default function TasksFilters({ notes, tags, children }: TasksFiltersProps) {
+export default function TasksFilters({ notes, tags, children, onFiltersChange }: TasksFiltersProps) {
   const [open, setOpen] = useState(false)
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -50,7 +52,7 @@ export default function TasksFilters({ notes, tags, children }: TasksFiltersProp
         <TasksFilterBar
           notes={notes}
           tags={tags}
-          onChange={() => {}}
+          onChange={filters => onFiltersChange?.(filters)}
           onApply={handleApply}
         />
       )}

--- a/supabase/migrations/20250415000000_full_text_search.sql
+++ b/supabase/migrations/20250415000000_full_text_search.sql
@@ -1,0 +1,270 @@
+-- Create extension for unaccent to improve search normalization
+create extension if not exists unaccent;
+
+-- Helper function to strip HTML tags and normalize whitespace
+create or replace function public.strip_html(input text)
+  returns text
+  language sql
+  immutable
+as $$
+  select trim(regexp_replace(regexp_replace(coalesce(input, ''), '<[^>]+>', ' ', 'gi'), '\s+', ' ', 'g'))
+$$;
+
+-- Ensure notes table has a search_vector column
+alter table public.notes
+  add column if not exists search_vector tsvector;
+
+-- Trigger function to keep the search_vector column in sync
+create or replace function public.notes_search_vector_trigger()
+  returns trigger
+  language plpgsql
+as $$
+declare
+  body_plain text;
+begin
+  body_plain := public.strip_html(new.body);
+  new.search_vector :=
+    setweight(to_tsvector('english', coalesce(new.title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(body_plain, '')), 'B');
+  return new;
+end;
+$$;
+
+-- Attach trigger to notes table
+create trigger notes_search_vector_update
+  before insert or update on public.notes
+  for each row
+  execute function public.notes_search_vector_trigger();
+
+-- Backfill existing rows
+update public.notes
+set search_vector = (
+  setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+  setweight(to_tsvector('english', coalesce(public.strip_html(body), '')), 'B')
+)
+where search_vector is null;
+
+-- Create the supporting GIN index
+create index if not exists notes_search_vector_idx
+  on public.notes using gin(search_vector);
+
+-- Table to persist parsed tasks
+create table if not exists public.note_tasks (
+  note_id uuid references public.notes(id) on delete cascade,
+  line integer not null,
+  text text not null,
+  tags text[] not null default array[]::text[],
+  due text,
+  status text,
+  is_completed boolean not null default false,
+  primary key (note_id, line)
+);
+
+-- Expression index to speed up task full-text search
+create index if not exists note_tasks_text_search_idx
+  on public.note_tasks using gin (to_tsvector('english', coalesce(text, '')));
+
+-- Enable RLS and mirror note ownership
+alter table public.note_tasks enable row level security;
+
+create policy "Note tasks are readable by note owners"
+  on public.note_tasks for select
+  using (
+    exists (
+      select 1 from public.notes n
+      where n.id = note_tasks.note_id
+        and n.user_id = auth.uid()
+    )
+  );
+
+create policy "Note tasks are writable by note owners"
+  on public.note_tasks for insert
+  with check (
+    exists (
+      select 1 from public.notes n
+      where n.id = note_tasks.note_id
+        and n.user_id = auth.uid()
+    )
+  );
+
+create policy "Note tasks are updatable by note owners"
+  on public.note_tasks for update
+  using (
+    exists (
+      select 1 from public.notes n
+      where n.id = note_tasks.note_id
+        and n.user_id = auth.uid()
+    )
+  )
+  with check (
+    exists (
+      select 1 from public.notes n
+      where n.id = note_tasks.note_id
+        and n.user_id = auth.uid()
+    )
+  );
+
+create policy "Note tasks are deletable by note owners"
+  on public.note_tasks for delete
+  using (
+    exists (
+      select 1 from public.notes n
+      where n.id = note_tasks.note_id
+        and n.user_id = auth.uid()
+    )
+  );
+
+-- Function returning ranked note search results
+create or replace function public.search_notes(
+  p_user_id uuid,
+  p_query text default null,
+  p_limit integer default 20,
+  p_offset integer default 0,
+  p_sort text default 'newest'
+)
+returns table (
+  id uuid,
+  title text,
+  updated_at timestamptz,
+  open_tasks integer,
+  highlight_title text,
+  highlight_body text,
+  rank double precision
+)
+language plpgsql
+stable
+as $$
+declare
+  ts_query tsquery;
+  order_direction text := case when p_sort = 'oldest' then 'asc' else 'desc' end;
+begin
+  if p_query is not null and btrim(p_query) <> '' then
+    ts_query := websearch_to_tsquery('english', p_query);
+  else
+    ts_query := null;
+  end if;
+
+  if ts_query is null then
+    return query
+    select
+      n.id,
+      n.title,
+      n.updated_at,
+      n.open_tasks,
+      null::text as highlight_title,
+      null::text as highlight_body,
+      0::double precision as rank
+    from public.notes n
+    where n.user_id = p_user_id
+    order by
+      case when order_direction = 'asc' then n.updated_at end asc,
+      case when order_direction = 'desc' then n.updated_at end desc
+    limit p_limit offset p_offset;
+  end if;
+
+  return query
+  select
+    n.id,
+    n.title,
+    n.updated_at,
+    n.open_tasks,
+    ts_headline(
+      'english',
+      coalesce(n.title, ''),
+      ts_query,
+      'StartSel=<mark>,StopSel=</mark>'
+    ) as highlight_title,
+    ts_headline(
+      'english',
+      public.strip_html(n.body),
+      ts_query,
+      'StartSel=<mark>,StopSel=</mark>,HighlightAll=true'
+    ) as highlight_body,
+    ts_rank_cd(n.search_vector, ts_query) as rank
+  from public.notes n
+  where n.user_id = p_user_id
+    and n.search_vector @@ ts_query
+  order by
+    ts_rank_cd(n.search_vector, ts_query) desc,
+    case when order_direction = 'asc' then n.updated_at end asc,
+    case when order_direction = 'desc' then n.updated_at end desc
+  limit p_limit offset p_offset;
+end;
+$$;
+
+-- Function returning ranked task search results
+create or replace function public.search_note_tasks(
+  p_user_id uuid,
+  p_query text default null,
+  p_limit integer default 20,
+  p_offset integer default 0,
+  p_completion text default null,
+  p_tag text default null,
+  p_note_id uuid default null,
+  p_due text default null,
+  p_sort text default 'text'
+)
+returns table (
+  note_id uuid,
+  line integer,
+  text text,
+  tags text[],
+  due text,
+  status text,
+  is_completed boolean,
+  note_title text,
+  note_updated_at timestamptz,
+  highlight text,
+  rank double precision
+)
+language plpgsql
+stable
+as $$
+declare
+  ts_query tsquery;
+  normalized_sort text := coalesce(p_sort, 'text');
+begin
+  if p_query is not null and btrim(p_query) <> '' then
+    ts_query := websearch_to_tsquery('english', p_query);
+  else
+    ts_query := null;
+  end if;
+
+  return query
+  select
+    t.note_id,
+    t.line,
+    t.text,
+    t.tags,
+    t.due,
+    t.status,
+    t.is_completed,
+    coalesce(n.title, public.strip_html(n.body)) as note_title,
+    n.updated_at,
+    case when ts_query is not null then
+      ts_headline(
+        'english',
+        t.text,
+        ts_query,
+        'StartSel=<mark>,StopSel=</mark>,HighlightAll=true'
+      )
+    else
+      null::text
+    end as highlight,
+    coalesce(ts_rank_cd(to_tsvector('english', coalesce(t.text, '')), ts_query), 0) as rank
+  from public.note_tasks t
+  join public.notes n on n.id = t.note_id
+  where n.user_id = p_user_id
+    and (p_note_id is null or t.note_id = p_note_id)
+    and (p_completion is null or (p_completion = 'open' and t.is_completed = false) or (p_completion = 'done' and t.is_completed = true))
+    and (p_tag is null or p_tag = any(t.tags))
+    and (p_due is null or t.due = p_due)
+    and (ts_query is null or to_tsvector('english', coalesce(t.text, '')) @@ ts_query)
+  order by
+    case when ts_query is not null then coalesce(ts_rank_cd(to_tsvector('english', coalesce(t.text, '')), ts_query), 0) end desc,
+    case when normalized_sort = 'due' then t.due end asc,
+    case when normalized_sort = 'text' then lower(t.text) end asc,
+    n.updated_at desc
+  limit p_limit offset p_offset;
+end;
+$$;

--- a/supabase/migrations/20250922104415_reload_search_functions.sql
+++ b/supabase/migrations/20250922104415_reload_search_functions.sql
@@ -1,0 +1,23 @@
+-- Ensure search RPC functions are accessible to PostgREST clients
+grant execute on function public.search_notes(
+  uuid,
+  text,
+  integer,
+  integer,
+  text
+) to authenticated, anon;
+
+grant execute on function public.search_note_tasks(
+  uuid,
+  text,
+  integer,
+  integer,
+  text,
+  text,
+  uuid,
+  text,
+  text
+) to authenticated, anon;
+
+-- Refresh PostgREST schema cache so the new grants take effect immediately
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- add Supabase migration for notes search_vector, note_tasks table, and RPC search helpers
- persist parsed tasks during note updates and expose /api/search endpoint for notes/tasks
- wire notes/tasks pages to server search with debounced queries, highlighting, and updated tests
- grant execute privileges on the search RPCs, refresh the PostgREST cache, and allow null filters in the /api/search schema
- surface initial task RPC failures as inline errors instead of crashing the Tasks page

## Testing
- npm run lint
- npm test
- CI=1 NEXT_PUBLIC_SUPABASE_URL=http://localhost NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_URL=http://localhost SUPABASE_ANON_KEY=dummy npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd2c75901c8327a6993c0943ca6cc7