### PR TITLE
feat: align task search page size

### DIFF
--- a/src/app/api/search/__tests__/route.test.ts
+++ b/src/app/api/search/__tests__/route.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { POST } from '../route'
 import { supabaseServer } from '@/lib/supabase-server'
+import { TASKS_PAGE_SIZE } from '@/lib/tasks/constants'
 
 vi.mock('@/lib/supabase-server', () => ({
   supabaseServer: vi.fn(),
@@ -45,6 +46,32 @@ describe('POST /api/search', () => {
       p_user_id: 'user-123',
       p_query: null,
       p_limit: 20,
+      p_offset: 0,
+      p_completion: null,
+      p_tag: null,
+      p_note_id: null,
+      p_due: null,
+      p_sort: 'text',
+    })
+  })
+
+  test('accepts maximum allowed page size for tasks', async () => {
+    const request = new Request('http://localhost/api/search', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ scope: 'tasks', pageSize: TASKS_PAGE_SIZE }),
+    })
+
+    const response = await POST(request)
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toEqual({ scope: 'tasks', page: 1, pageSize: TASKS_PAGE_SIZE, results: [] })
+
+    expect(rpcMock).toHaveBeenCalledWith('search_note_tasks', {
+      p_user_id: 'user-123',
+      p_query: null,
+      p_limit: TASKS_PAGE_SIZE,
       p_offset: 0,
       p_completion: null,
       p_tag: null,

--- a/src/app/api/search/route.ts
+++ b/src/app/api/search/route.ts
@@ -1,13 +1,14 @@
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { supabaseServer } from '@/lib/supabase-server'
+import { TASKS_PAGE_SIZE } from '@/lib/tasks/constants'
 
 export const dynamic = 'force-dynamic'
 
 const baseSchema = z.object({
   query: z.string().nullish(),
   page: z.number().int().min(1).optional(),
-  pageSize: z.number().int().min(1).max(100).optional(),
+  pageSize: z.number().int().min(1).max(TASKS_PAGE_SIZE).optional(),
 })
 
 const notesSchema = baseSchema.extend({

--- a/src/app/tasks/TasksClient.tsx
+++ b/src/app/tasks/TasksClient.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import TaskRow from '@/components/tasks/TaskRow'
 import { useSearchParams } from 'next/navigation'
 import { NavButton } from '@/components/NavButton'
+import { TASKS_PAGE_SIZE } from '@/lib/tasks/constants'
 
 type NoteOption = { id: string; title: string }
 
@@ -79,7 +80,7 @@ export function TasksClient({ notes, tags, initialFilters, initialTasks }: Tasks
             due: filters.due ?? null,
             sort: filters.sort ?? 'text',
             page: 1,
-            pageSize: 200,
+            pageSize: TASKS_PAGE_SIZE,
           }),
           signal: controller.signal,
         })

--- a/src/app/tasks/page.tsx
+++ b/src/app/tasks/page.tsx
@@ -4,6 +4,7 @@ import { supabaseServer } from '@/lib/supabase-server'
 import { redirect } from 'next/navigation'
 import { extractTitleFromHtml } from '@/lib/note'
 import TasksClient from './TasksClient'
+import { TASKS_PAGE_SIZE } from '@/lib/tasks/constants'
 
 type SearchParamMap = Record<string, string | string[] | undefined>
 
@@ -50,7 +51,7 @@ export default async function TasksPage({
   const { data: taskRows, error: taskError } = await supabase.rpc('search_note_tasks', {
     p_user_id: user.id,
     p_query: initialFilters.search ?? null,
-    p_limit: 200,
+    p_limit: TASKS_PAGE_SIZE,
     p_offset: 0,
     p_completion: initialFilters.completion ?? null,
     p_tag: initialFilters.tag ?? null,

--- a/src/lib/tasks/constants.ts
+++ b/src/lib/tasks/constants.ts
@@ -1,0 +1,1 @@
+export const TASKS_PAGE_SIZE = 200 as const


### PR DESCRIPTION
## Summary
- export a shared TASKS_PAGE_SIZE constant and reuse it in the search API validation
- update the tasks UI and initial Supabase fetch to use the shared page size value
- cover the maximum allowed page size in the search API route tests

## Testing
- npm run lint
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d13e35b38483279f2d52b8e7f38940