### PR TITLE
Use stored note metadata on index

### DIFF
--- a/src/app/notes/__tests__/NotesPage.test.tsx
+++ b/src/app/notes/__tests__/NotesPage.test.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+(globalThis as unknown as { React: typeof React }).React = React;
+import { render } from "@testing-library/react";
+import { vi } from "vitest";
+import type { Note } from "../NotesList";
+
+const { redirect: redirectMock } = vi.hoisted(() => ({
+  redirect: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({
+  redirect: redirectMock,
+}));
+
+const mockCountOpenTasks = vi.fn(() => {
+  throw new Error("countOpenTasks should not be called");
+});
+vi.mock("@/lib/taskparse", () => ({
+  countOpenTasks: mockCountOpenTasks,
+}));
+
+const mockExtractTitleFromHtml = vi.fn(() => {
+  throw new Error("extractTitleFromHtml should not be called");
+});
+vi.mock("@/lib/note", () => ({
+  extractTitleFromHtml: mockExtractTitleFromHtml,
+}));
+
+let capturedNotes: Note[] | undefined;
+vi.mock("../NotesClient", () => ({
+  NotesClient: ({ notes }: { notes: Note[] }) => {
+    capturedNotes = notes;
+    return <div data-testid="notes-client" />;
+  },
+}));
+
+vi.mock("@/components/NavButton", () => ({
+  NavButton: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+vi.mock("@/components/quick-capture/QuickCaptureButton", () => ({
+  QuickCaptureButton: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+const select = vi.fn();
+const order = vi.fn();
+const from = vi.fn();
+
+const supabaseMock = {
+  auth: {
+    getUser: vi.fn(async () => ({ data: { user: { id: "user-1" } } })),
+  },
+  from: from.mockImplementation((table: string) => {
+    if (table !== "notes") {
+      throw new Error(`Unexpected table query: ${table}`);
+    }
+    return {
+      select: select.mockImplementation((columns: string) => {
+        if (columns !== "id,title,open_tasks,updated_at") {
+          throw new Error(`Unexpected column selection: ${columns}`);
+        }
+        return {
+          order: order.mockImplementation(() =>
+            Promise.resolve({
+              data: [
+                {
+                  id: "note-1",
+                  title: "Persisted Title",
+                  open_tasks: 2,
+                  updated_at: "2024-04-20T00:00:00Z",
+                },
+              ],
+            }),
+          ),
+        };
+      }),
+    };
+  }),
+};
+
+vi.mock("@/lib/supabase-server", () => ({
+  supabaseServer: async () => supabaseMock,
+}));
+
+import NotesPage from "../page";
+
+test("renders using stored note metadata", async () => {
+  capturedNotes = undefined;
+
+  const view = await NotesPage();
+  render(view);
+
+  expect(from).toHaveBeenCalledWith("notes");
+  expect(select).toHaveBeenCalledWith("id,title,open_tasks,updated_at");
+  expect(order).toHaveBeenCalledWith("updated_at", { ascending: false });
+  expect(capturedNotes).toEqual([
+    {
+      id: "note-1",
+      title: "Persisted Title",
+      updated_at: "2024-04-20T00:00:00Z",
+      openTasks: 2,
+      highlightTitle: null,
+      highlightBody: null,
+    },
+  ]);
+  expect(mockCountOpenTasks).not.toHaveBeenCalled();
+  expect(mockExtractTitleFromHtml).not.toHaveBeenCalled();
+  expect(redirectMock).not.toHaveBeenCalled();
+});

--- a/supabase/migrations/20250420000000_backfill_note_metadata.sql
+++ b/supabase/migrations/20250420000000_backfill_note_metadata.sql
@@ -1,0 +1,43 @@
+-- Backfill persisted note metadata for deployments that predate title/open task columns
+with metadata as (
+  select
+    n.id,
+    coalesce(
+      nullif(btrim(n.title), ''),
+      nullif(btrim(substring(n.body from '(?is)<h1[^>]*>(.*?)</h1>')), ''),
+      nullif(btrim(public.strip_html(n.body)), ''),
+      'Untitled'
+    ) as fallback_title,
+    coalesce(
+      (
+        select count(*)::numeric
+        from (
+          select lower(match[1]) as checked
+          from regexp_matches(
+            coalesce(n.body, ''),
+            '<li[^>]*data-type="taskItem"[^>]*data-checked="([^\"]]*)"[^>]*>',
+            'gi'
+          ) as match
+        ) as extracted
+        where coalesce(extracted.checked, '') not in ('true', 't', '1', 'yes')
+      ),
+      0::numeric
+    ) as fallback_open_tasks
+  from public.notes n
+)
+update public.notes as n
+set
+  title = case
+    when n.title is null or btrim(n.title) = '' then metadata.fallback_title
+    else n.title
+  end,
+  open_tasks = case
+    when n.open_tasks is null then metadata.fallback_open_tasks
+    else n.open_tasks
+  end
+from metadata
+where n.id = metadata.id
+  and (
+    (n.title is null or btrim(n.title) = '')
+    or n.open_tasks is null
+  );


### PR DESCRIPTION
## Summary
- load the notes listing using the persisted title/open task metadata instead of parsing HTML
- backfill existing rows with titles and open task counts to support the lightweight query
- add regression coverage that verifies the page only requests the minimal note fields

## Testing
- npm run lint
- npm test
- npm run build *(fails: requires Supabase env vars in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1456472408327a3752f4c4806f8c3