### PR TITLE
Ensure favicon metadata points to public asset

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,9 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://stratella.vercel.app'),
   title: 'Stratella',
   description: 'All your tasks from every note, in one place. Markdown in, clarity out.',
+  icons: {
+    icon: '/favicon.ico',
+  },
   openGraph: {
     title: 'Stratella',
     description: 'All your tasks. From every note. In one place.',


### PR DESCRIPTION
## Summary
- reference the favicon through Next.js metadata icons so the correct link tag is emitted

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68da8dfb06588327b30b41b55d19a4b0